### PR TITLE
[Feature] 헤더 UI 구현(뒤로가기, 닫기버튼)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.10.0",
         "bootstrap": "^5.3.7",
+        "lucide-vue-next": "^0.525.0",
         "moment": "^2.30.1",
         "pinia": "^3.0.3",
         "vue": "^3.5.17",
@@ -2804,7 +2805,6 @@
       "resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.7.0.tgz",
       "integrity": "sha512-ku2uNz5MaZ9IerPPUyOHzyjhXoX2kVJaVf7hL315DC17vS6IiZRmmCPfggNbU16QTvM80+uYYy3eYJB59WCtvg==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "typescript": "5.x",
         "vue": "^3.4.0"
@@ -4923,6 +4923,14 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-vue-next": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-0.525.0.tgz",
+      "integrity": "sha512-Xf8+x8B2DrnGDV/rxylS+KBp2FIe6ljwDn2JsGTZZvXIfhmm/q+nv8RuGO1OyoMjOVkkz7CqtUqJfwtFPRbB2w==",
+      "peerDependencies": {
+        "vue": ">=3.0.1"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.17",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "axios": "^1.10.0",
     "bootstrap": "^5.3.7",
+    "lucide-vue-next": "^0.525.0",
     "moment": "^2.30.1",
     "pinia": "^3.0.3",
     "vue": "^3.5.17",

--- a/src/components/common/topbar/Header.vue
+++ b/src/components/common/topbar/Header.vue
@@ -1,0 +1,48 @@
+<script lang="ts" setup>
+import { defineProps, defineEmits } from 'vue'
+import { ChevronLeft, XCircle } from 'lucide-vue-next'
+
+const props = defineProps<{
+  title: string
+  showLeftIcon?: boolean
+  showRightIcon?: boolean
+}>()
+
+const emits = defineEmits<{
+  (e: 'left-click'): void
+  (e: 'right-click'): void
+}>()
+
+const onLeftClick = () => emits('left-click')
+const onRightClick = () => emits('right-click')
+</script>
+
+<template>
+  <div
+    class="position-relative d-flex align-items-center justify-content-center border-bottom bg-white px-3"
+    style="height: 4rem"
+  >
+    <!-- 왼쪽 아이콘(뒤로가기) -->
+    <div
+      v-if="showLeftIcon"
+      class="position-absolute start-0 ps-3 d-flex align-items-center"
+      @click="onLeftClick"
+      style="cursor: pointer"
+    >
+      <ChevronLeft :size="24" />
+    </div>
+
+    <!-- 제목 -->
+    <div class="fw-semibold text-center">{{ title }}</div>
+
+    <!-- 오른쪽 아이콘(닫기버튼) -->
+    <div
+      v-if="showRightIcon"
+      class="position-absolute end-0 pe-3 d-flex align-items-center"
+      @click="onRightClick"
+      style="cursor: pointer"
+    >
+      <XCircle :size="1.5 * 16" style="color: var(--Gray05)" />
+    </div>
+  </div>
+</template>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,8 @@
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import './assets/styles/reset.css'
-import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap/dist/css/bootstrap.css'
+import './assets/styles/main.css'
 
 import App from './App.vue'
 import router from './router'


### PR DESCRIPTION
## 📌 Issues
- closed #SCRUM-72

## 🏁 Work Description
- 헤더 UI 구현
- 뒤로가기 아이콘 (`ChevronLeft`)
- 가운데 title 
- 닫기 아이콘 (`XCircle`)
- 필요 시 좌/우 아이콘 조건부 렌더링

## 💬 PR Points
- 컴포넌트명 : Header
- props: `title`, `showLeftIcon`, `showRightIcon`
- 이벤트: `@left-click`, `@right-click` emit 처리
- 디자인: 높이 64px(`4rem`), 아이콘 사이즈 `1.5~1.75rem`
- 사용예시 
<Header
    title="테스트 제목"
    :showLeftIcon="true"
    :showRightIcon="true"
    @left-click="onLeft"
    @right-click="onRight"
  />
const onLeft = () => {
  // 뒤로가기 로직
}

const onRight = () => {
  // 닫기 로직
}



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 새로운 상단바 컴포넌트가 추가되어, 제목과 좌/우 아이콘 표시 및 클릭 이벤트를 지원합니다.

* **Chores**
  * lucide-vue-next 아이콘 라이브러리가 추가되었습니다.
  * 메인 스타일시트(main.css)가 새롭게 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->