### PR TITLE
[Feature] Header 컴포넌트 tailwind 변경

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,21 @@
 <script setup lang="ts">
 import { RouterLink, RouterView } from 'vue-router'
 import MainHeader from './components/common/topbar/MainHeader.vue'
+import Header from './components/common/topbar/Header.vue'
+import PayHeader from './components/common/topbar/PayHeader.vue'
 </script>
 
 <template>
   <RouterView />
   <MainHeader />
+  <Header
+    title="테스트 제목"
+    :showLeftIcon="true"
+    :showRightIcon="true"
+    @left-click="onLeft"
+    @right-click="onRight"
+  />
+  <PayHeader />
 </template>
 
 <style scoped></style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { RouterLink, RouterView } from 'vue-router'
+import MainHeader from './components/common/topbar/MainHeader.vue'
 </script>
 
 <template>
   <RouterView />
+  <MainHeader />
 </template>
 
 <style scoped></style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,21 +1,9 @@
 <script setup lang="ts">
 import { RouterLink, RouterView } from 'vue-router'
-import MainHeader from './components/common/topbar/MainHeader.vue'
-import Header from './components/common/topbar/Header.vue'
-import PayHeader from './components/common/topbar/PayHeader.vue'
 </script>
 
 <template>
   <RouterView />
-  <MainHeader />
-  <Header
-    title="테스트 제목"
-    :showLeftIcon="true"
-    :showRightIcon="true"
-    @left-click="onLeft"
-    @right-click="onRight"
-  />
-  <PayHeader />
 </template>
 
 <style scoped></style>

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -1,3 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  html {
+    font-family: 'Pretendard', sans-serif;
+  }
+}
+
 /* @font-face {
   font-family: 'Pretendard';
   src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff')

--- a/src/components/common/topbar/Header.vue
+++ b/src/components/common/topbar/Header.vue
@@ -46,7 +46,7 @@ const onRightClick = () => emits('right-click')
       class="absolute right-0 pr-3 flex items-center cursor-pointer"
       @click="onRightClick"
     >
-      <XCircle :size="24" class="text-Gray-5" />
+      <XCircle :size="24" class="text-Gray-5" role="button" aria-label="닫기" />
     </div>
   </div>
 </template>

--- a/src/components/common/topbar/Header.vue
+++ b/src/components/common/topbar/Header.vue
@@ -25,11 +25,11 @@ const onRightClick = () => emits('right-click')
 </script>
 
 <template>
-  <div class="header-wrapper d-flex align-items-center justify-content-center bg-white px-3">
+  <div class="relative flex items-center justify-center px-3 h-[7.2rem] bg-white">
     <!-- 왼쪽 아이콘 -->
     <div
       v-if="showLeftIcon"
-      class="left-icon position-absolute start-0 ps-3 d-flex align-items-center"
+      class="absolute left-0 pl-3 flex items-center cursor-pointer"
       @click="onLeftClick"
       role="button"
       aria-label="뒤로가기"
@@ -38,30 +38,15 @@ const onRightClick = () => emits('right-click')
     </div>
 
     <!-- 제목 -->
-    <div class="Head0 text-center">{{ title }}</div>
+    <div class="text-center Head0">{{ title }}</div>
 
     <!-- 오른쪽 아이콘 -->
     <div
       v-if="showRightIcon"
-      class="right-icon position-absolute end-0 pe-3 d-flex align-items-center"
+      class="absolute right-0 pr-3 flex items-center cursor-pointer"
       @click="onRightClick"
     >
-      <XCircle :size="24" class="close-icon" />
+      <XCircle :size="24" class="text-Gray-5" />
     </div>
   </div>
 </template>
-
-<style scoped>
-.header-wrapper {
-  height: 4rem;
-}
-
-.left-icon,
-.right-icon {
-  cursor: pointer;
-}
-
-.close-icon {
-  color: var(--Gray05);
-}
-</style>

--- a/src/components/common/topbar/MainHeader.vue
+++ b/src/components/common/topbar/MainHeader.vue
@@ -7,7 +7,7 @@ defineEmits(['left-click'])
   <div class="flex items-center justify-start w-full h-[7.2rem] pt-4 pb-4 px-4 bg-white">
     <!-- 왼쪽 로고 -->
     <div class="pl-4 cursor-pointer" @click="$emit('left-click')">
-      <img src="@/assets/images/danji-logo-main.png" alt="단지 로고" class="h-14" />
+      <img src="../../../assets/images/danji-logo-main.png" alt="단지 로고" class="h-14" />
     </div>
   </div>
 </template>

--- a/src/components/common/topbar/MainHeader.vue
+++ b/src/components/common/topbar/MainHeader.vue
@@ -4,31 +4,10 @@ defineEmits(['left-click'])
 </script>
 
 <template>
-  <div class="main-header">
+  <div class="flex items-center justify-start w-full h-[7.2rem] pt-4 pb-4 px-4 bg-white">
     <!-- 왼쪽 로고 -->
-    <div class="main-header-logo" @click="$emit('left-click')">
-      <img src="@/assets/images/danji-logo-main.png" alt="단지 로고" />
+    <div class="pl-4 cursor-pointer" @click="$emit('left-click')">
+      <img src="@/assets/images/danji-logo-main.png" alt="단지 로고" class="h-14" />
     </div>
   </div>
 </template>
-
-<style scoped>
-.main-header {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  background-color: white;
-  padding: 1rem 1rem 0 1rem;
-  width: 100%;
-  height: 4.5rem;
-}
-
-.main-header-logo {
-  padding-left: 1rem;
-  cursor: pointer;
-}
-
-.main-header-logo img {
-  height: 3rem;
-}
-</style>

--- a/src/components/common/topbar/PayHeader.vue
+++ b/src/components/common/topbar/PayHeader.vue
@@ -3,7 +3,7 @@ import { XCircle } from 'lucide-vue-next'
 </script>
 
 <template>
-  <div class="flex items-center bg-white px-3 h-[72px]">
+  <div class="flex items-center bg-white px-3 h-[72rem]">
     <!-- 왼쪽 텍스트 -->
     <div class="Head0 flex-1 pl-3">단지Pay</div>
 

--- a/src/components/common/topbar/PayHeader.vue
+++ b/src/components/common/topbar/PayHeader.vue
@@ -1,16 +1,15 @@
 <script setup lang="ts">
-import '@/assets/styles/main.css'
 import { XCircle } from 'lucide-vue-next'
 </script>
 
 <template>
-  <div class="d-flex align-items-center bg-white px-3" style="height: 4rem">
+  <div class="flex items-center bg-white px-3 h-[72px]">
     <!-- 왼쪽 텍스트 -->
-    <div class="Head01 flex-grow-1 ps-3">단지Pay</div>
+    <div class="Head0 flex-1 pl-3">단지Pay</div>
 
     <!-- 오른쪽 닫기 아이콘 -->
     <div class="cursor-pointer" @click="$emit('right-click')">
-      <XCircle :size="24" class="text-secondary" />
+      <XCircle :size="24" class="text-Gray-5" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
## 📌 Issues
- closed #19 

## 🏁 Work Description
- tailwind 변경 사항에 따른 css 변경 및 헤더 높이 통일

## 💬 PR Points
- header, MainHeader, PayHeader 수정 완료했습니다 !
- pretendard 적용이 되지 않아 직접 main.css에 pretendard 적용 시켰습니다

## 📷 Screenshot
<img width="468" height="302" alt="image" src="https://github.com/user-attachments/assets/5c88dba9-5f88-4ce6-a2d4-ef860e4debbe" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Tailwind CSS가 프로젝트에 통합되어 기존 Bootstrap 및 커스텀 CSS 스타일이 Tailwind 유틸리티 클래스로 대체되었습니다.
  * 주요 헤더, 일반 헤더, 결제 헤더 컴포넌트의 레이아웃 및 스타일이 Tailwind CSS를 사용하도록 변경되었습니다.
  * 불필요한 CSS import 및 커스텀 스타일 정의가 제거되었습니다.
  * 기본 폰트가 'Pretendard'로 지정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->