### PR TITLE
[Refactor/scrum] : 96 layout refactor

### DIFF
--- a/src/components/common/topbar/PayHeader.vue
+++ b/src/components/common/topbar/PayHeader.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import { XCircle } from 'lucide-vue-next'
-</script>
 
+const emits = defineEmits<{
+  (e: 'right-click'): void
+}>()
+
+const onRightClick = () => emits('right-click')
+</script>
 <template>
   <div class="flex items-center bg-white px-3 h-[7.2rem]">
     <!-- 왼쪽 텍스트 -->

--- a/src/components/common/topbar/PayHeader.vue
+++ b/src/components/common/topbar/PayHeader.vue
@@ -13,7 +13,7 @@ const onRightClick = () => emits('right-click')
     <div class="Head0 flex-1 pl-3">단지Pay</div>
 
     <!-- 오른쪽 닫기 아이콘 -->
-    <div class="cursor-pointer" @click="$emit('right-click')">
+    <div class="cursor-pointer" @click="onRightClick">
       <XCircle :size="24" class="text-Gray-5" />
     </div>
   </div>

--- a/src/components/common/topbar/SettingHeader.vue
+++ b/src/components/common/topbar/SettingHeader.vue
@@ -2,14 +2,15 @@
 import '@/assets/styles/main.css'
 import { defineProps, defineEmits } from 'vue'
 import { ChevronLeft, Settings } from 'lucide-vue-next'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
 
 const props = withDefaults(
   defineProps<{
     title: string
     showLeftIcon?: boolean
     showRightIcon?: boolean
-    emitLeftClick?: () => void
-    emitRightClick?: () => void
   }>(),
   {
     showLeftIcon: false,
@@ -23,7 +24,12 @@ const emits = defineEmits<{
 }>()
 
 const onLeftClick = () => emits('left-click')
-const onRightClick = () => emits('right-click')
+
+// SettingHeader에서 설정 아이콘 클릭 시
+const onRightClick = () => {
+  emits('right-click')
+  router.push('/card/setting')
+}
 </script>
 
 <template>

--- a/src/components/common/topbar/SettingHeader.vue
+++ b/src/components/common/topbar/SettingHeader.vue
@@ -8,6 +8,8 @@ const props = withDefaults(
     title: string
     showLeftIcon?: boolean
     showRightIcon?: boolean
+    emitLeftClick?: () => void
+    emitRightClick?: () => void
   }>(),
   {
     showLeftIcon: false,

--- a/src/components/layout/Layout.vue
+++ b/src/components/layout/Layout.vue
@@ -5,6 +5,7 @@ import PayHeader from '../common/topbar/PayHeader.vue'
 import Header from '../common/topbar/Header.vue'
 import BottomNav from '../common/bottomnav/BottomNav.vue'
 import SettingHeader from '../common/topbar/SettingHeader.vue'
+import { useRouter } from 'vue-router'
 
 /**
  * Layout 컴포넌트
@@ -50,10 +51,21 @@ const headerProps = withDefaults(defineProps<LayoutProps>(), {
   isBottomNav: true,
 })
 
+// 표준 뒤로가기
+const handleBack = () => {
+  if (window.history.length > 1) {
+    router.back()
+  } else {
+    router.push('/')
+  }
+}
+
 const emit = defineEmits<{
   (e: 'left-click'): void
   (e: 'right-click'): void
 }>()
+
+const router = useRouter()
 </script>
 <template>
   <div class="flex flex-col h-screen">
@@ -68,16 +80,16 @@ const emit = defineEmits<{
       :title="headerProps.headerTitle"
       :show-left-icon="headerProps.showLeftIcon"
       :show-right-icon="headerProps.showRightIcon"
-      @left-click="headerProps.emitLeftIconClick"
-      @right-click="headerProps.emitRightIconClick"
+      @left-click="handleBack"
+      @right-click="emit('right-click')"
     />
     <SettingHeader
       v-else-if="headerProps.headerType === 'setting'"
       :title="headerProps.headerTitle"
       :show-left-icon="headerProps.showLeftIcon"
       :show-right-icon="headerProps.showRightIcon"
-      @left-click="headerProps.emitLeftIconClick"
-      @right-click="headerProps.emitRightIconClick"
+      @left-click="handleBack"
+      @right-click="emit('right-click')"
     />
 
     <!-- 메인 콘텐츠 영역 (페이지별 컴포넌트가 들어갈 곳) -->

--- a/src/components/layout/Layout.vue
+++ b/src/components/layout/Layout.vue
@@ -4,6 +4,7 @@ import MainHeader from '../common/topbar/MainHeader.vue'
 import PayHeader from '../common/topbar/PayHeader.vue'
 import Header from '../common/topbar/Header.vue'
 import BottomNav from '../common/bottomnav/BottomNav.vue'
+import SettingHeader from '../common/topbar/SettingHeader.vue'
 
 /**
  * Layout 컴포넌트
@@ -48,17 +49,35 @@ const headerProps = withDefaults(defineProps<LayoutProps>(), {
   showRightIcon: false,
   isBottomNav: true,
 })
+
+const emit = defineEmits<{
+  (e: 'left-click'): void
+  (e: 'right-click'): void
+}>()
 </script>
 <template>
   <div class="flex flex-col h-screen">
     <!-- 헤더 타입에 따라 다른 컴포넌트 렌더링 -->
     <MainHeader v-if="headerProps.headerType === 'main'" />
-    <PayHeader v-else-if="headerProps.headerType === 'pay'" />
+    <PayHeader
+      v-else-if="headerProps.headerType === 'pay'"
+      @right-click="headerProps.emitRightIconClick"
+    />
     <Header
       v-else-if="headerProps.headerType === 'basic'"
       :title="headerProps.headerTitle"
       :show-left-icon="headerProps.showLeftIcon"
       :show-right-icon="headerProps.showRightIcon"
+      @left-click="headerProps.emitLeftIconClick"
+      @right-click="headerProps.emitRightIconClick"
+    />
+    <SettingHeader
+      v-else-if="headerProps.headerType === 'setting'"
+      :title="headerProps.headerTitle"
+      :show-left-icon="headerProps.showLeftIcon"
+      :show-right-icon="headerProps.showRightIcon"
+      @left-click="headerProps.emitLeftIconClick"
+      @right-click="headerProps.emitRightIconClick"
     />
 
     <!-- 메인 콘텐츠 영역 (페이지별 컴포넌트가 들어갈 곳) -->

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,24 +1,30 @@
 // 바텀네비 아이템 타입
 export type BottomNaviType = 'wallet' | 'map' | 'qr' | 'badge' | 'my'
 
-// 레이아웃에서 사용하는 헤더 타입
+// 공통 레이아웃에서 사용하는 헤더 타입
+export type HeaderType = 'basic' | 'main' | 'pay' | 'setting'
+
+// 레이아웃 컴포넌트에서 사용하는 공통 타입
+export interface BaseLayoutProps {
+  isBottomNav?: boolean
+}
+
+interface HeaderWithTitle {
+  headerTitle: string
+  showLeftIcon?: boolean
+  showRightIcon?: boolean
+  emitLeftIconClick?: () => void
+  emitRightIconClick?: () => void
+}
+
+interface PayHeaderProps {
+  headerTitle: string
+  showRightIcon?: boolean
+  emitRightIconClick?: () => void
+}
+
+// 헤더 타입에 따른 레이아웃 컴포넌트 props
 export type LayoutProps =
-  | {
-      headerType: 'basic'
-      headerTitle: string
-      showLeftIcon?: boolean
-      showRightIcon?: boolean
-      isBottomNav?: boolean
-    }
-  | {
-      headerType: 'main'
-      isBottomNav?: boolean
-    }
-  | {
-      headerType: 'pay'
-      isBottomNav?: boolean
-    }
-  | {
-      headerType: 'none'
-      isBottomNav?: boolean
-    }
+  | ({ headerType: 'basic' | 'setting' } & HeaderWithTitle & BaseLayoutProps)
+  | ({ headerType: 'main' } & BaseLayoutProps)
+  | ({ headerType: 'pay' } & PayHeaderProps & BaseLayoutProps)

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -13,8 +13,6 @@ interface HeaderWithTitle {
   headerTitle: string
   showLeftIcon?: boolean
   showRightIcon?: boolean
-  emitLeftIconClick?: () => void
-  emitRightIconClick?: () => void
 }
 
 interface PayHeaderProps {

--- a/src/views/pay/PayCompletePage.vue
+++ b/src/views/pay/PayCompletePage.vue
@@ -13,7 +13,7 @@ const handlePayment = () => {
 }
 </script>
 <template>
-  <Layout :header-type="'basic'" :header-title="'결제하기'" :is-bottom-nav="false">
+  <layout :header-type="'basic'" :header-title="'결제하기'" :is-bottom-nav="false">
     <template #content>
       <div class="relative flex flex-col items-center h-full px-[2rem] pt-[6rem] bg-Gray-0">
         <!-- 결제 성공 -->
@@ -31,6 +31,6 @@ const handlePayment = () => {
         >
       </div>
     </template>
-  </Layout>
+  </layout>
 </template>
 <style scoped></style>

--- a/src/views/pay/PayPage.vue
+++ b/src/views/pay/PayPage.vue
@@ -61,11 +61,12 @@ const onClickPay = () => {
 // }
 </script>
 <template>
-  <Layout
+  <layout
     :header-type="'basic'"
     :header-title="'결제하기'"
     :show-right-icon="true"
     :is-bottom-nav="false"
+    @right-click="router.push('/home')"
   >
     <template #content>
       <div class="relative flex flex-col items-center h-full px-[1.6rem] pt-[1.1rem] bg-Gray-0">
@@ -153,6 +154,6 @@ const onClickPay = () => {
       <LocalPayFailModal v-if="showLocalFailModal" @close="showLocalFailModal = false" />
       <CashPayFailModal v-if="showCashFailModal" @close="showCashFailModal = false" />
     </template>
-  </Layout>
+  </layout>
 </template>
 <style scoped></style>


### PR DESCRIPTION
## 📌 Issues
- closed #43

## 🏁 Work Description
- 공용 레이아웃 업데이트
    - SettingHeader 추가
    - 렌더링을 위한 emit 관련 속성 추가(선택 prop이니까 안 쓸거면 생략 가능)

## 💬 PR Points
### 수정된 Layout 사용법입니다!

**Layout 사용하는 페이지 컴포넌트에서**

```vue
  <layout
    :header-type="'basic'"
    :header-title="'결제하기'"
    :show-right-icon="true"
    :is-bottom-nav="false"
    @right-click="router.push('/home')"
  >
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * 새로운 헤더 타입(SettingHeader)이 레이아웃에 추가되어 다양한 헤더 구성을 지원합니다.
  * SettingHeader 및 PayHeader에서 우측 클릭 이벤트를 사용할 수 있습니다.
  * PayPage에서 우측 클릭 이벤트 발생 시 홈으로 이동하는 네비게이션이 추가되었습니다.

* **Refactor**
  * 레이아웃 관련 타입 구조가 개선되어 헤더 타입별 속성 정의가 더 명확해졌습니다.
  * 공통 속성과 이벤트 핸들러가 중앙화되어 코드 일관성이 향상되었습니다.
  * 레이아웃 컴포넌트에서 좌측 클릭 시 뒤로 가기 또는 홈으로 이동하는 일관된 네비게이션 처리 로직이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->