### PR TITLE
[Fix/SCRUM-105] : main UI 수정

### DIFF
--- a/src/components/common/card/UserCard.vue
+++ b/src/components/common/card/UserCard.vue
@@ -1,8 +1,18 @@
 <script setup lang="ts">
-defineProps<{
+import { defineProps } from 'vue'
+import { useRouter } from 'vue-router'
+
+const props = defineProps<{
+  id: number
   balance: number
   backgroundImageUrl: string
 }>()
+
+const router = useRouter()
+
+const goToHistory = () => {
+  router.push(`/card/history/${props.id}`)
+}
 </script>
 
 <template>
@@ -10,6 +20,7 @@ defineProps<{
   <div
     class="relative w-full aspect-[1586/1000] mx-auto rounded-xl bg-cover bg-center border border-solid border-Gray-3"
     :style="{ backgroundImage: `url(${backgroundImageUrl})` }"
+    @click="goToHistory"
   >
     <!-- 오른쪽 하단 잔액  -->
     <div class="absolute bottom-2 right-3 py-1 px-3 bg-white text-Brown-4 Head02 rounded">

--- a/src/components/common/tooltip/Tooltip.vue
+++ b/src/components/common/tooltip/Tooltip.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount } from 'vue'
+import { HelpCircle } from 'lucide-vue-next'
+
+const props = defineProps<{
+  message: string // 툴팁 텍스트
+}>()
+
+const showTooltip = ref(false)
+const tooltipRef = ref<HTMLElement | null>(null)
+const iconRef = ref<HTMLElement | null>(null)
+
+const handleClickOutside = (e: MouseEvent) => {
+  const target = e.target as HTMLElement
+  if (
+    tooltipRef.value &&
+    !tooltipRef.value.contains(target) &&
+    iconRef.value &&
+    !iconRef.value.contains(target)
+  ) {
+    showTooltip.value = false
+  }
+}
+
+onMounted(() => document.addEventListener('click', handleClickOutside))
+onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
+</script>
+
+<template>
+  <div class="relative flex items-center">
+    <!-- lucide HelpCircle 아이콘 -->
+    <HelpCircle
+      ref="iconRef"
+      class="w-[1.6rem] h-[1.6rem] text-Gray-5 cursor-pointer"
+      @click.stop="showTooltip = !showTooltip"
+    />
+
+    <!-- 툴팁 -->
+    <div
+      v-if="showTooltip"
+      ref="tooltipRef"
+      class="absolute rounded-md shadow z-50 top-full right-0 mt-[0.5rem] p-[1rem] w-max bg-Black-2 text-White-0 Body04"
+    >
+      {{ message }}
+    </div>
+  </div>
+</template>

--- a/src/components/common/tooltip/Tooltip.vue
+++ b/src/components/common/tooltip/Tooltip.vue
@@ -28,7 +28,6 @@ onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
 
 <template>
   <div class="relative flex items-center">
-    <!-- lucide HelpCircle 아이콘 -->
     <HelpCircle
       ref="iconRef"
       class="w-[1.6rem] h-[1.6rem] text-Gray-5 cursor-pointer"
@@ -39,7 +38,7 @@ onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
     <div
       v-if="showTooltip"
       ref="tooltipRef"
-      class="absolute rounded-md shadow z-50 top-full right-0 mt-[0.5rem] p-[1rem] w-max bg-Black-2 text-White-0 Body04"
+      class="absolute top-full right-0 mt-[0.5rem] p-[1rem] w-max rounded-md shadow z-50 top-full right-0 mt-[0.5rem] p-[1rem] w-max bg-Black-2 text-White-0 Body04"
     >
       {{ message }}
     </div>

--- a/src/components/common/tooltip/Tooltip.vue
+++ b/src/components/common/tooltip/Tooltip.vue
@@ -1,10 +1,29 @@
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount } from 'vue'
+import { ref, onMounted, onBeforeUnmount, computed } from 'vue'
 import { HelpCircle } from 'lucide-vue-next'
 
-const props = defineProps<{
-  message: string // 툴팁 텍스트
-}>()
+const props = withDefaults(
+  defineProps<{
+    message: string
+    position?: 'top' | 'bottom' | 'left' | 'right'
+    align?: 'start' | 'center' | 'end'
+  }>(),
+  {
+    position: 'top',
+    align: 'center',
+  },
+)
+// 사용법
+// 1. 아래쪽/왼쪽 중앙
+// <Tooltip message="원하는 메세지 적기" position="bottom" align="center" />
+// <Tooltip message="" position="left" align="center" />
+
+// 2. 왼/오른쪽 상단
+// <Tooltip message="" position="top" align="start" />
+// <Tooltip message="" position="top" align="end" />
+
+// 3. 오른쪽 하단
+// <Tooltip message="" position="right" align="end" />
 
 const showTooltip = ref(false)
 const tooltipRef = ref<HTMLElement | null>(null)
@@ -24,6 +43,27 @@ const handleClickOutside = (e: MouseEvent) => {
 
 onMounted(() => document.addEventListener('click', handleClickOutside))
 onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
+
+// 위치별 계산
+const tooltipPositionClass = computed(() => {
+  const pos = props.position || 'top'
+  const align = props.align || 'center'
+
+  const base: Record<string, string> = {
+    top: 'bottom-full mb-2',
+    bottom: 'top-full mt-2',
+    left: 'right-full mr-2',
+    right: 'left-full ml-2',
+  }
+
+  const alignClass: Record<string, string> = {
+    start: 'left-0',
+    center: 'left-1/2 -translate-x-1/2',
+    end: 'right-0',
+  }
+
+  return `${base[pos]} ${alignClass[align]}`
+})
 </script>
 
 <template>
@@ -36,7 +76,7 @@ onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
     <div
       v-if="showTooltip"
       ref="tooltipRef"
-      class="absolute z-50 top-full left-1/2 p-[0.8rem] mt-[0.4rem] -translate-x-1/2 rounded-md shadow bg-Black-2 text-White-0 Body04 whitespace-nowrap"
+      :class="`absolute z-50 p-[0.8rem] rounded-md shadow bg-Black-2 text-White-0 Body04 whitespace-nowrap ${tooltipPositionClass}`"
     >
       {{ message }}
     </div>

--- a/src/components/common/tooltip/Tooltip.vue
+++ b/src/components/common/tooltip/Tooltip.vue
@@ -33,12 +33,10 @@ onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
       class="w-[1.6rem] h-[1.6rem] text-Gray-5 cursor-pointer"
       @click.stop="showTooltip = !showTooltip"
     />
-
-    <!-- 툴팁 -->
     <div
       v-if="showTooltip"
       ref="tooltipRef"
-      class="absolute top-full right-0 mt-[0.5rem] p-[1rem] w-max rounded-md shadow z-50 top-full right-0 mt-[0.5rem] p-[1rem] w-max bg-Black-2 text-White-0 Body04"
+      class="absolute z-50 top-full left-1/2 p-[0.8rem] mt-[0.4rem] -translate-x-1/2 rounded-md shadow bg-Black-2 text-White-0 Body04 whitespace-nowrap"
     >
       {{ message }}
     </div>

--- a/src/components/common/tooltip/Tooltip.vue
+++ b/src/components/common/tooltip/Tooltip.vue
@@ -71,11 +71,18 @@ const tooltipPositionClass = computed(() => {
     <HelpCircle
       ref="iconRef"
       class="w-[1.6rem] h-[1.6rem] text-Gray-5 cursor-pointer"
+      role="button"
+      :aria-label="`도움말: ${message}`"
+      :aria-expanded="showTooltip"
+      tabindex="0"
       @click.stop="showTooltip = !showTooltip"
+      @keydown.enter.space.stop="showTooltip = !showTooltip"
     />
     <div
       v-if="showTooltip"
       ref="tooltipRef"
+      role="tooltip"
+      :aria-hidden="!showTooltip"
       :class="`absolute z-50 p-[0.8rem] rounded-md shadow bg-Black-2 text-White-0 Body04 whitespace-nowrap ${tooltipPositionClass}`"
     >
       {{ message }}

--- a/src/components/wallet/HasCardSection.vue
+++ b/src/components/wallet/HasCardSection.vue
@@ -68,6 +68,7 @@ onMounted(() => {
           class="!w-[275px] shrink-0"
         >
           <UserCard
+            :id="card.id"
             :balance="card.balance"
             :backgroundImageUrl="card.backgroundImageUrl"
             class="w-full"

--- a/src/components/wallet/TotalWallet.vue
+++ b/src/components/wallet/TotalWallet.vue
@@ -24,7 +24,7 @@ const goWalletPage = () => {
 
     <!-- 하단 영역: 1/3 비율 -->
     <div
-      class="bg-White-0/40 p-4 flex items-center justify-end flex-[1] gap-1"
+      class="flex items-center justify-end flex-[1] gap-1 p-4 bg-White-0/40 p-4"
       @click="goWalletPage"
     >
       <span class="Body02 text-Gray-6"> 지역화폐 잔액 보기 </span>

--- a/src/components/wallet/TotalWallet.vue
+++ b/src/components/wallet/TotalWallet.vue
@@ -28,7 +28,7 @@ const goWalletPage = () => {
       @click="goWalletPage"
     >
       <span class="Body02 text-Gray-6"> 지역화폐 잔액 보기 </span>
-      <ChevronRight class="text-Gray-6 w-5 h-5" />
+      <ChevronRight class="w-5 h-5 text-Gray-6" />
     </div>
   </div>
 </template>

--- a/src/components/wallet/TotalWallet.vue
+++ b/src/components/wallet/TotalWallet.vue
@@ -1,8 +1,18 @@
 <script setup lang="ts">
+import { useRouter } from 'vue-router'
+import { ChevronRight } from 'lucide-vue-next'
+
+const router = useRouter()
+
 defineProps<{
   walletAmount: number
   totalAsset: number
 }>()
+
+// 통합 지갑 선택시 총자산보기 페이지 이동
+const goWalletPage = () => {
+  router.push('/wallet/view')
+}
 </script>
 <template>
   <div class="aspect-[1586/700] rounded-xl overflow-hidden w-full shadow mx-auto flex flex-col">
@@ -13,10 +23,12 @@ defineProps<{
     </div>
 
     <!-- 하단 영역: 1/3 비율 -->
-    <div class="bg-White-0/40 p-4 flex-[1]">
-      <span class="Body02 text-Black-2"
-        >사용자님의 총 자산 {{ totalAsset.toLocaleString() }}원</span
-      >
+    <div
+      class="bg-White-0/40 p-4 flex items-center justify-end flex-[1] gap-1"
+      @click="goWalletPage"
+    >
+      <span class="Body02 text-Gray-6"> 지역화폐 잔액 보기 </span>
+      <ChevronRight class="text-Gray-6 w-5 h-5" />
     </div>
   </div>
 </template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -54,8 +54,10 @@ const routes = [
     component: LocalCardCreatePage,
   },
   {
-    path: '/card/history',
+    path: '/card/history/:id',
+    name: 'CardHistory',
     component: CardHistoryPage,
+    props: true,
   },
   {
     path: '/card/charge',

--- a/src/views/wallet/change/OrderChangePage.vue
+++ b/src/views/wallet/change/OrderChangePage.vue
@@ -58,17 +58,9 @@ const saveOrder = () => {
     :is-bottom-nav="false"
   >
     <template #content>
-      <div class="flex flex-col h-full px-[1.5rem] py-[2rem] bg-background">
+      <div class="flex flex-col h-full px-[1.5rem] py-[2rem] bg-Background">
         <div class="flex-1 overflow-y-auto">
           <div class="mb-[1rem] Body04 text-Black2">지갑 순서를 바꿔보세요</div>
-
-          <!-- 통합지갑 고정 -->
-          <wallet-item
-            :name="cards[0].name"
-            :balance="cards[0].balance"
-            :bgColorClass="cards[0].bgColorClass"
-            :showMenu="false"
-          />
 
           <draggable
             v-model="otherCards"

--- a/src/views/wallet/history/CardHistoryPage.vue
+++ b/src/views/wallet/history/CardHistoryPage.vue
@@ -177,7 +177,11 @@ onBeforeUnmount(() => {
           </div>
           <div class="flex justify-between text-Gray-7">
             <span>충전 가능 금액:</span>
-            <span>{{ (cardInfo!.maximum - cardInfo!.chargedThisMonth).toLocaleString() }}원</span>
+            <span
+              >{{
+                cardInfo ? (cardInfo.maximum - cardInfo.chargedThisMonth).toLocaleString() : '0'
+              }}원</span
+            >
           </div>
         </div>
       </div>

--- a/src/views/wallet/history/CardHistoryPage.vue
+++ b/src/views/wallet/history/CardHistoryPage.vue
@@ -4,7 +4,7 @@ import { useRoute } from 'vue-router'
 
 import Layout from '@/components/layout/Layout.vue'
 import CardHistoryItemList from '@/components/common/history/CardHistoryItemList.vue'
-import { HelpCircle } from 'lucide-vue-next'
+import Tooltip from '@/components/common/tooltip/Tooltip.vue'
 
 // 카드 ID
 const route = useRoute()
@@ -138,23 +138,10 @@ onBeforeUnmount(() => {
               <p class="Body01 text-Black-2">이번 달 혜택 :</p>
               <p class="Body01 text-Blue-0">{{ cardInfo?.benefit.toLocaleString() }}원</p>
 
-              <!-- 툴팁 아이콘 -->
-              <HelpCircle
-                ref="iconRef"
-                class="w-[1.2rem] h-[1.2rem] text-Gray-5 cursor-pointer"
-                @click.stop="showTooltip = !showTooltip"
+              <!-- 툴팁  -->
+              <tooltip
+                :message="`이번달 ${cardInfo?.name}의 ${cardInfo?.benefit_type}은 ${cardInfo?.percentage}% 입니다.`"
               />
-
-              <!-- 툴팁 -->
-              <div
-                v-if="showTooltip"
-                ref="tooltipRef"
-                @click.stop
-                class="absolute rounded-md shadow z-50 top-full left-0 mt-[0.5rem] p-[1rem] w-max bg-Black-2 text-White-0 Body04"
-              >
-                이번달 {{ cardInfo?.name }}의 {{ cardInfo?.benefit_type }}은
-                {{ cardInfo?.percentage }} %입니다.
-              </div>
             </div>
           </div>
 

--- a/src/views/wallet/history/CardHistoryPage.vue
+++ b/src/views/wallet/history/CardHistoryPage.vue
@@ -1,28 +1,73 @@
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount } from 'vue'
+import { ref, onMounted, onBeforeUnmount, computed } from 'vue'
+import { useRoute } from 'vue-router'
+
 import Layout from '@/components/layout/Layout.vue'
 import CardHistoryItemList from '@/components/common/history/CardHistoryItemList.vue'
-import { CircleQuestionMark } from 'lucide-vue-next'
+import { HelpCircle } from 'lucide-vue-next'
 
-// 카드 정보 더미데이터 (추후 API 연동 예정)
-const cardInfo = ref({
-  name: '부산지역화폐',
-  balance: 101000,
-  benefit: 10000,
-  maximum: 500000,
-  chargedThisMonth: 100000,
-  benefit_type: '인센티브',
-  percentage: 7,
-})
-// 거래 내역 더미데이터 (추후 API 연동 예정)
-const transaction: {
+// 카드 ID
+const route = useRoute()
+const cardId = Number(route.params.id)
+
+// 카드 데이터 (추후 API 연동 예정)
+const allCards = [
+  {
+    id: 1,
+    name: '동백전',
+    balance: 32000,
+    benefit: 10000,
+    maximum: 500000,
+    chargedThisMonth: 100000,
+    benefit_type: '캐시백',
+    percentage: 10,
+  },
+  {
+    id: 2,
+    name: '서울Pay',
+    balance: 15000,
+    benefit: 5000,
+    maximum: 500000,
+    chargedThisMonth: 120000,
+    benefit_type: '캐시백',
+    percentage: 5,
+  },
+  {
+    id: 3,
+    name: '강원상품권',
+    balance: 25000,
+    benefit: 7000,
+    maximum: 500000,
+    chargedThisMonth: 80000,
+    benefit_type: '인센티브',
+    percentage: 7,
+  },
+  {
+    id: 4,
+    name: '부산Pay',
+    balance: 25000,
+    benefit: 8000,
+    maximum: 500000,
+    chargedThisMonth: 70000,
+    benefit_type: '인센티브',
+    percentage: 8,
+  },
+]
+
+// 현재 카드 정보
+const cardInfo = computed(() => allCards.find((c) => c.id === cardId))
+
+// 거래 내역 더미 데이터
+interface HistoryItem {
   comment: string
   amount: number
   afterBalance: number
   direction: 'INCOME' | 'EXPENSE'
   type: 'CHARGE' | 'REFUND' | 'CONVERT' | 'PAYMENT'
   createdAt: string
-}[] = [
+}
+
+const transaction: HistoryItem[] = [
   {
     comment: '가맹점',
     amount: 10000,
@@ -40,14 +85,6 @@ const transaction: {
     createdAt: '2025-07-18T10:20:40',
   },
   {
-    comment: '단지',
-    amount: 500000,
-    afterBalance: 501000,
-    direction: 'INCOME',
-    type: 'CHARGE',
-    createdAt: '2025-05-10T10:20:40',
-  },
-  {
     comment: '단지카페',
     amount: 100000,
     afterBalance: 501000,
@@ -55,15 +92,8 @@ const transaction: {
     type: 'PAYMENT',
     createdAt: '2025-04-18T10:20:40',
   },
-  {
-    comment: '단지',
-    amount: 500000,
-    afterBalance: 501000,
-    direction: 'INCOME',
-    type: 'CHARGE',
-    createdAt: '2025-02-18T10:20:40',
-  },
 ]
+
 const showTooltip = ref(false)
 const tooltipRef = ref<HTMLElement | null>(null)
 const iconRef = ref<HTMLElement | null>(null)
@@ -90,9 +120,9 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <layout
+  <Layout
     :header-type="'basic'"
-    :header-title="'카드이름'"
+    :header-title="cardInfo?.name || '카드 상세'"
     :is-bottom-nav="false"
     :showLeftIcon="true"
   >
@@ -102,28 +132,28 @@ onBeforeUnmount(() => {
         <div class="flex justify-between items-center mb-[2rem]">
           <!-- 카드 정보 -->
           <div>
-            <p class="Body04 text-Black-2">{{ cardInfo.name }}</p>
-            <p class="Head0 text-Black-2">{{ cardInfo.balance.toLocaleString() }} 원</p>
+            <p class="Body04 text-Black-2">{{ cardInfo?.name }}</p>
+            <p class="Head0 text-Black-2">{{ cardInfo?.balance.toLocaleString() }} 원</p>
             <div class="flex items-center gap-2 relative">
               <p class="Body01 text-Black-2">이번 달 혜택 :</p>
-              <p class="Body01 text-Blue-0">{{ cardInfo.benefit.toLocaleString() }}원</p>
+              <p class="Body01 text-Blue-0">{{ cardInfo?.benefit.toLocaleString() }}원</p>
 
               <!-- 툴팁 아이콘 -->
-              <CircleQuestionMark
+              <HelpCircle
                 ref="iconRef"
                 class="w-[1.2rem] h-[1.2rem] text-Gray-5 cursor-pointer"
                 @click.stop="showTooltip = !showTooltip"
               />
 
-              <!-- 툴팁 : 문구 너비만큼 유동적 -->
+              <!-- 툴팁 -->
               <div
                 v-if="showTooltip"
                 ref="tooltipRef"
                 @click.stop
                 class="absolute rounded-md shadow z-50 top-full left-0 mt-[0.5rem] p-[1rem] w-max bg-Black-2 text-White-0 Body04"
               >
-                이번달 {{ cardInfo.name }}의 {{ cardInfo.benefit_type }}은
-                {{ cardInfo.percentage }} %입니다.
+                이번달 {{ cardInfo?.name }}의 {{ cardInfo?.benefit_type }}은
+                {{ cardInfo?.percentage }} %입니다.
               </div>
             </div>
           </div>
@@ -139,15 +169,15 @@ onBeforeUnmount(() => {
         <div class="bg-Gray-1 rounded-xl p-[1.4rem] Body00 text-Black-2">
           <div class="flex justify-between mb-[1rem] text-Gray-7">
             <span>이번 달 충전한 금액:</span>
-            <span>{{ cardInfo.chargedThisMonth.toLocaleString() }}원</span>
+            <span>{{ cardInfo?.chargedThisMonth.toLocaleString() }}원</span>
           </div>
           <div class="flex justify-between mb-[1rem] text-Gray-7">
             <span>충전 최대 한도:</span>
-            <span>{{ cardInfo.maximum.toLocaleString() }}원</span>
+            <span>{{ cardInfo?.maximum.toLocaleString() }}원</span>
           </div>
           <div class="flex justify-between text-Gray-7">
-            <span>충전한 가능 금액:</span>
-            <span>{{ (cardInfo.maximum - cardInfo.chargedThisMonth).toLocaleString() }}원</span>
+            <span>충전 가능 금액:</span>
+            <span>{{ (cardInfo!.maximum - cardInfo!.chargedThisMonth).toLocaleString() }}원</span>
           </div>
         </div>
       </div>
@@ -155,5 +185,5 @@ onBeforeUnmount(() => {
       <!-- 이용 내역 리스트 -->
       <CardHistoryItemList :histories="transaction" />
     </template>
-  </layout>
+  </Layout>
 </template>

--- a/src/views/wallet/history/CardHistoryPage.vue
+++ b/src/views/wallet/history/CardHistoryPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, computed } from 'vue'
+import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 
 import Layout from '@/components/layout/Layout.vue'
@@ -93,30 +93,6 @@ const transaction: HistoryItem[] = [
     createdAt: '2025-04-18T10:20:40',
   },
 ]
-
-const showTooltip = ref(false)
-const tooltipRef = ref<HTMLElement | null>(null)
-const iconRef = ref<HTMLElement | null>(null)
-
-const handleClickOutside = (e: MouseEvent) => {
-  const target = e.target as HTMLElement
-  if (
-    tooltipRef.value &&
-    !tooltipRef.value.contains(target) &&
-    iconRef.value &&
-    !iconRef.value.contains(target)
-  ) {
-    showTooltip.value = false
-  }
-}
-
-onMounted(() => {
-  document.addEventListener('click', handleClickOutside)
-})
-
-onBeforeUnmount(() => {
-  document.removeEventListener('click', handleClickOutside)
-})
 </script>
 
 <template>
@@ -138,8 +114,9 @@ onBeforeUnmount(() => {
               <p class="Body01 text-Black-2">이번 달 혜택 :</p>
               <p class="Body01 text-Blue-0">{{ cardInfo?.benefit.toLocaleString() }}원</p>
 
-              <!-- 툴팁  -->
-              <tooltip
+              <!-- Tooltip 컴포넌트 사용 -->
+              <Tooltip
+                position="bottom"
                 :message="`이번달 ${cardInfo?.name}의 ${cardInfo?.benefit_type}은 ${cardInfo?.percentage}% 입니다.`"
               />
             </div>

--- a/src/views/wallet/home/HomePage.vue
+++ b/src/views/wallet/home/HomePage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useRouter } from 'vue-router'
 import { ref } from 'vue'
+
 import Layout from '@/components/layout/Layout.vue'
 import DanjiButton from '@/components/common/button/DanjiButton.vue'
 import TotalWallet from '@/components/wallet/TotalWallet.vue'
@@ -19,9 +20,12 @@ interface Card {
 
 const router = useRouter()
 
-// 충전 버튼 선택시 충전하기 페이지 이동
 const goChangePage = () => {
   router.push('/card/charge')
+}
+
+const goCardHistory = (id: number) => {
+  router.push(`/card/history/${id}`)
 }
 
 const hasCard = true
@@ -76,11 +80,13 @@ const cards = ref<Card[]>([
             <TotalWallet :wallet-amount="82000" :total-asset="582000" />
           </div>
         </div>
+
         <!-- 나의 지역화폐카드 -->
         <div class="pl-20 pt-[4rem] pb-[3rem] px-[1rem]">
-          <HasCardSection v-if="hasCard" :cards="cards" />
+          <HasCardSection v-if="hasCard" :cards="cards" @click-card="goCardHistory" />
           <NoCardSection v-else />
         </div>
+
         <!-- 버튼 -->
         <div class="flex justify-center gap-10">
           <danji-button variant="small" @click="goChangePage">충전</danji-button>

--- a/src/views/wallet/home/HomePage.vue
+++ b/src/views/wallet/home/HomePage.vue
@@ -71,13 +71,13 @@ const cards = ref<Card[]>([
     <template #content>
       <div class="min-h-full bg-Background">
         <!-- 통합지갑 section -->
-        <div class="flex justify-center pt-10">
+        <div class="flex justify-center pt-[3rem]">
           <div class="w-[270px]">
             <TotalWallet :wallet-amount="82000" :total-asset="582000" />
           </div>
         </div>
         <!-- 나의 지역화폐카드 -->
-        <div class="pl-20 pt-20 pb-10 px-4">
+        <div class="pl-20 pt-[4rem] pb-[3rem] px-[1rem]">
           <HasCardSection v-if="hasCard" :cards="cards" />
           <NoCardSection v-else />
         </div>

--- a/src/views/wallet/home/HomePage.vue
+++ b/src/views/wallet/home/HomePage.vue
@@ -19,11 +19,6 @@ interface Card {
 
 const router = useRouter()
 
-// 통합 지갑 선택시 총자산보기 페이지 이동
-const goWalletPage = () => {
-  router.push('/wallet/view')
-}
-
 // 충전 버튼 선택시 충전하기 페이지 이동
 const goChangePage = () => {
   router.push('/card/charge')
@@ -82,7 +77,7 @@ const cards = ref<Card[]>([
           </div>
         </div>
         <!-- 나의 지역화폐카드 -->
-        <div class="pl-20 pt-20 pb-10 px-4" @click="goWalletPage">
+        <div class="pl-20 pt-20 pb-10 px-4">
           <HasCardSection v-if="hasCard" :cards="cards" />
           <NoCardSection v-else />
         </div>

--- a/src/views/wallet/home/HomePage.vue
+++ b/src/views/wallet/home/HomePage.vue
@@ -76,13 +76,13 @@ const cards = ref<Card[]>([
     <template #content>
       <div class="min-h-full bg-Background">
         <!-- 통합지갑 section -->
-        <div class="flex justify-center pt-10" @click="goWalletPage">
+        <div class="flex justify-center pt-10">
           <div class="w-[270px]">
             <TotalWallet :wallet-amount="82000" :total-asset="582000" />
           </div>
         </div>
         <!-- 나의 지역화폐카드 -->
-        <div class="pl-20 pt-20 pb-10 px-4">
+        <div class="pl-20 pt-20 pb-10 px-4" @click="goWalletPage">
           <HasCardSection v-if="hasCard" :cards="cards" />
           <NoCardSection v-else />
         </div>

--- a/src/views/wallet/home/WalletPage.vue
+++ b/src/views/wallet/home/WalletPage.vue
@@ -1,33 +1,7 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue'
-
-import { HelpCircle } from 'lucide-vue-next'
 import Layout from '@/components/layout/Layout.vue'
 import WalletItem from '@/components/common/wallet/WalletItem.vue'
-
-const showTooltip = ref(false)
-const tooltipRef = ref<HTMLElement | null>(null)
-const iconRef = ref<HTMLElement | null>(null)
-
-// 바깥 클릭 시 툴팁 닫기
-const handleClickOutside = (e: MouseEvent) => {
-  const target = e.target as HTMLElement
-  if (
-    tooltipRef.value &&
-    !tooltipRef.value.contains(target) &&
-    iconRef.value &&
-    !iconRef.value.contains(target)
-  ) {
-    showTooltip.value = false
-  }
-}
-
-onMounted(() => {
-  document.addEventListener('click', handleClickOutside)
-})
-onUnmounted(() => {
-  document.removeEventListener('click', handleClickOutside)
-})
+import Tooltip from '@/components/common/tooltip/Tooltip.vue'
 
 interface WalletCard {
   id: number
@@ -38,22 +12,28 @@ interface WalletCard {
 
 const cards: WalletCard[] = [
   {
+    id: 1,
+    name: '서울Pay',
+    balance: 32000,
+    bgColorClass: 'bg-[#0078D7] text-White-1',
+  },
+  {
     id: 2,
-    name: '울산페이',
+    name: '강원상품권',
     balance: 39400,
-    bgColorClass: 'bg-[#77C3E4] text-white',
+    bgColorClass: 'bg-[#77C3E4] text-White-1',
   },
   {
     id: 3,
-    name: '강릉페이',
+    name: '동백전',
     balance: 39400,
-    bgColorClass: 'bg-[#C89E59] text-white',
+    bgColorClass: 'bg-[#C89E59] text-White-1',
   },
   {
     id: 4,
-    name: '부산페이',
+    name: '부산Pay',
     balance: 39400,
-    bgColorClass: 'bg-[#F1F1F1] text-black',
+    bgColorClass: 'bg-[#F1F1F1] text-Black-1',
   },
 ]
 </script>
@@ -68,9 +48,7 @@ const cards: WalletCard[] = [
     <template #content>
       <div class="flex flex-col h-full px-[1rem] py-[2.4rem] bg-Background gap-4">
         <!-- 상단 총 잔액 영역 -->
-        <div
-          class="flex items-center justify-between p-[2rem] rounded-lg shadow-sm bg-White-1 rounded-lg shadow-sm p-[2rem]"
-        >
+        <div class="flex items-center justify-between p-[2rem] rounded-lg shadow-sm bg-White-1">
           <!-- 왼쪽 텍스트 -->
           <p class="Body00 text-Gray-4">
             사용자의 지역화폐 총 잔액은
@@ -80,23 +58,12 @@ const cards: WalletCard[] = [
             입니다.
           </p>
 
-          <!-- 툴팁 아이콘 -->
-          <div class="relative flex items-center">
-            <HelpCircle
-              ref="iconRef"
-              class="w-[1.6rem] h-[1.6rem] text-Gray-5 cursor-pointer"
-              @click.stop="showTooltip = !showTooltip"
-            />
-
-            <div
-              v-if="showTooltip"
-              ref="tooltipRef"
-              @click.stop
-              class="absolute mt-[0.5rem] p-[1rem] w-max rounded-md shadow z-50 top-full right-0 bg-Black-2 text-White-0 Body04"
-            >
-              통합지갑을 제외한 나의 각 지역화폐카드 잔액을 한 눈에 볼 수 있습니다.
-            </div>
-          </div>
+          <!-- 툴팁 컴포넌트 -->
+          <tooltip
+            message="통합지갑을 제외한 나의 각 지역화폐카드 잔액을 한 눈에 볼 수 있습니다."
+            position="bottom"
+            align="end"
+          />
         </div>
 
         <!-- 카드 리스트 -->

--- a/src/views/wallet/home/WalletPage.vue
+++ b/src/views/wallet/home/WalletPage.vue
@@ -68,7 +68,9 @@ const cards: WalletCard[] = [
     <template #content>
       <div class="flex flex-col h-full px-[1rem] py-[2.4rem] bg-Background gap-4">
         <!-- 상단 총 잔액 영역 -->
-        <div class="bg-white rounded-lg shadow-sm p-[2rem] flex items-center justify-between">
+        <div
+          class="flex items-center justify-between p-[2rem] rounded-lg shadow-sm bg-White-1 rounded-lg shadow-sm p-[2rem]"
+        >
           <!-- 왼쪽 텍스트 -->
           <p class="Body00 text-Gray-4">
             사용자의 지역화폐 총 잔액은

--- a/src/views/wallet/home/WalletPage.vue
+++ b/src/views/wallet/home/WalletPage.vue
@@ -1,7 +1,34 @@
 <script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+
+import { HelpCircle } from 'lucide-vue-next'
 import Layout from '@/components/layout/Layout.vue'
 import WalletItem from '@/components/common/wallet/WalletItem.vue'
-// 더미 데이터
+
+const showTooltip = ref(false)
+const tooltipRef = ref<HTMLElement | null>(null)
+const iconRef = ref<HTMLElement | null>(null)
+
+// 바깥 클릭 시 툴팁 닫기
+const handleClickOutside = (e: MouseEvent) => {
+  const target = e.target as HTMLElement
+  if (
+    tooltipRef.value &&
+    !tooltipRef.value.contains(target) &&
+    iconRef.value &&
+    !iconRef.value.contains(target)
+  ) {
+    showTooltip.value = false
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside)
+})
+onUnmounted(() => {
+  document.removeEventListener('click', handleClickOutside)
+})
+
 interface WalletCard {
   id: number
   name: string
@@ -10,12 +37,6 @@ interface WalletCard {
 }
 
 const cards: WalletCard[] = [
-  {
-    id: 1,
-    name: '통합지갑',
-    balance: 39400,
-    bgColorClass: 'bg-[#F6E3A2] text-black',
-  },
   {
     id: 2,
     name: '울산페이',
@@ -36,26 +57,55 @@ const cards: WalletCard[] = [
   },
 ]
 </script>
+
 <template>
   <layout
     :header-type="'basic'"
-    :header-title="'나의 총 자산'"
+    :header-title="'나의 지역화폐'"
     :is-bottom-nav="false"
     :showLeftIcon="true"
   >
     <template #content>
-      <div class="flex flex-col h-full px-[1.5rem] py-[2rem] bg-background gap-4">
-        <wallet-item
-          v-for="card in cards"
-          :key="card.id"
-          :name="card.name"
-          :balance="card.balance"
-          :bgColorClass="card.bgColorClass"
-          :showMenu="false"
-        />
+      <div class="flex flex-col h-full px-[1rem] py-[2.4rem] bg-Background gap-4">
+        <!-- 상단 총 잔액 영역 -->
+        <div class="bg-white rounded-lg shadow-sm p-[2rem] flex items-center justify-between">
+          <!-- 왼쪽 텍스트 -->
+          <p class="Body02 text-Gray-4">
+            사용자의 지역화폐 총 잔액은
+            <span class="text-Blue-0 font-semibold">930,000원</span> 입니다.
+          </p>
+
+          <!-- 툴팁 아이콘 -->
+          <div class="relative flex items-center">
+            <HelpCircle
+              ref="iconRef"
+              class="w-[1.6rem] h-[1.6rem] text-Gray-5 cursor-pointer"
+              @click.stop="showTooltip = !showTooltip"
+            />
+
+            <div
+              v-if="showTooltip"
+              ref="tooltipRef"
+              @click.stop
+              class="absolute rounded-md shadow z-50 top-full right-0 mt-[0.5rem] p-[1rem] w-max bg-Black-2 text-White-0 Body04"
+            >
+              통합지갑을 제외한 나의 각 지역화폐카드 잔액을 한 눈에 볼 수 있습니다.
+            </div>
+          </div>
+        </div>
+
+        <!-- 카드 리스트 -->
+        <div class="bg-white rounded-lg shadow-sm p-4 flex flex-col gap-4 flex-1">
+          <wallet-item
+            v-for="card in cards"
+            :key="card.id"
+            :name="card.name"
+            :balance="card.balance"
+            :bgColorClass="card.bgColorClass"
+            :showMenu="false"
+          />
+        </div>
       </div>
     </template>
   </layout>
 </template>
-
-<style scoped></style>

--- a/src/views/wallet/home/WalletPage.vue
+++ b/src/views/wallet/home/WalletPage.vue
@@ -72,7 +72,10 @@ const cards: WalletCard[] = [
           <!-- 왼쪽 텍스트 -->
           <p class="Body00 text-Gray-4">
             사용자의 지역화폐 총 잔액은
-            <span class="text-Blue-0">930,000원</span> 입니다.
+            <span class="text-Blue-0"
+              >{{ cards.reduce((sum, card) => sum + card.balance, 0).toLocaleString() }}원</span
+            >
+            입니다.
           </p>
 
           <!-- 툴팁 아이콘 -->

--- a/src/views/wallet/home/WalletPage.vue
+++ b/src/views/wallet/home/WalletPage.vue
@@ -92,7 +92,7 @@ const cards: WalletCard[] = [
               v-if="showTooltip"
               ref="tooltipRef"
               @click.stop
-              class="absolute rounded-md shadow z-50 top-full right-0 mt-[0.5rem] p-[1rem] w-max bg-Black-2 text-White-0 Body04"
+              class="absolute mt-[0.5rem] p-[1rem] w-max rounded-md shadow z-50 top-full right-0 bg-Black-2 text-White-0 Body04"
             >
               통합지갑을 제외한 나의 각 지역화폐카드 잔액을 한 눈에 볼 수 있습니다.
             </div>
@@ -100,7 +100,7 @@ const cards: WalletCard[] = [
         </div>
 
         <!-- 카드 리스트 -->
-        <div class="bg-white rounded-lg shadow-sm p-4 flex flex-col gap-4 flex-1">
+        <div class="flex flex-col gap-4 flex-1 p-4 rounded-lg shadow-sm bg-White-1">
           <wallet-item
             v-for="card in cards"
             :key="card.id"

--- a/src/views/wallet/home/WalletPage.vue
+++ b/src/views/wallet/home/WalletPage.vue
@@ -70,9 +70,9 @@ const cards: WalletCard[] = [
         <!-- 상단 총 잔액 영역 -->
         <div class="bg-white rounded-lg shadow-sm p-[2rem] flex items-center justify-between">
           <!-- 왼쪽 텍스트 -->
-          <p class="Body02 text-Gray-4">
+          <p class="Body00 text-Gray-4">
             사용자의 지역화폐 총 잔액은
-            <span class="text-Blue-0 font-semibold">930,000원</span> 입니다.
+            <span class="text-Blue-0">930,000원</span> 입니다.
           </p>
 
           <!-- 툴팁 아이콘 -->


### PR DESCRIPTION
## 📌 Issues
- closed #52 

## 🏁 Work Description
- 멘토링 피드백 후 수정된 UI로 수정했습니다

## 💬 PR Points
- 메인화면 : '사용자 총 자산' -> '지역화폐 잔액 보기' 로 변경하였습니다
- 기존 통합지갑클릭시 wallet으로 넘어가던 걸, 지역화폐 잔액 보기 클릭시로 넘어갈 수 있도록 click seciton 수정했습니다
- (아래부터 추가 된 내용입니다)
- Tooltip 이 반복되서 사용되는 중이라 컴포넌트로 구성하였습니다.
-  선언할 때 position과 align 을 이용하여 위치조정이 가능하며, {{meassage}}로 원하는 멘트로 구현 가능합니다

## 📷 Screenshot
<img width="463" height="830" alt="image" src="https://github.com/user-attachments/assets/77c02eca-5b13-4f25-bffe-c1019dab9fee" />

<img width="465" height="827" alt="image" src="https://github.com/user-attachments/assets/0103df6b-441b-42a6-9568-885da65132be" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 지역화폐 총 잔액에 대한 설명 툴팁이 추가되었습니다. 도움말 아이콘을 클릭하면 안내 문구가 표시됩니다.
  * 카드 목록에서 각 카드를 클릭하면 해당 카드의 거래 내역 페이지로 이동합니다.
  * 지갑 하단 영역의 "지역화폐 잔액 보기"가 클릭 가능한 영역으로 변경되어 해당 페이지로 이동할 수 있습니다.
  * 툴팁 컴포넌트가 새롭게 도입되어 다양한 위치와 정렬 옵션을 지원합니다.

* **기능 개선**
  * "나의 총 자산" 헤더가 "나의 지역화폐"로 변경되었습니다.
  * 통합지갑 카드가 지갑 카드 목록에서 제거되었습니다.
  * 일부 UI 섹션의 패딩 및 정렬이 rem 단위로 조정되어 더욱 일관된 레이아웃을 제공합니다.
  * 총 자산 영역이 클릭 가능한 버튼에서 안내 영역으로 변경되었습니다.
  * 지갑 카드 순서 변경 화면에서 통합지갑 항목이 더 이상 중복 표시되지 않습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->