### PR TITLE
[Feature/scrum 104] : 지도 UI 구현

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,1 +1,8 @@
 /// <reference types="vite/client" />
+interface ImportMetaEnv {
+  readonly VITE_KAKAO_APP_API_KEY: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "vue-datepicker-next": "^1.0.3",
         "vue-router": "^4.5.1",
         "vue3-datepicker": "^0.4.0",
+        "vue3-kakao-maps": "^2.3.10",
         "vuedraggable": "^4.1.0"
       },
       "devDependencies": {
@@ -7071,6 +7072,12 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/kakao.maps.d.ts": {
+      "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.40.tgz",
+      "integrity": "sha512-nX69MB1ok04epe3OqS+/tEeWBbU31GSQbvDPJmQRRltzzqn6t4jBsO5v1nzalUjCKzwcH2CptOc767NZ7Hbu3g==",
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -10719,6 +10726,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/vue3-kakao-maps": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/vue3-kakao-maps/-/vue3-kakao-maps-2.3.10.tgz",
+      "integrity": "sha512-vzzxvdw1ZtyID4clA/LFg++Qf1uTq49ksnL3ejqbp/rB+WVRrulSQ0ja+L929VFehbQY628lJPsp9KwxC6VrNA==",
+      "license": "MIT",
+      "dependencies": {
+        "kakao.maps.d.ts": "^0.1.39"
       }
     },
     "node_modules/vuedraggable": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "vue-datepicker-next": "^1.0.3",
     "vue-router": "^4.5.1",
     "vue3-datepicker": "^0.4.0",
+    "vue3-kakao-maps": "^2.3.10",
     "vuedraggable": "^4.1.0"
   },
   "devDependencies": {

--- a/src/components/common/chip/DanjiChip.vue
+++ b/src/components/common/chip/DanjiChip.vue
@@ -14,7 +14,7 @@ import { ChevronDown } from 'lucide-vue-next'
  *
  * @example 아이콘 포함
  * ```vue
- * <danji-chip :isIcon="true">더보기</danji-chip>
+ * <danji-chip :is-icon="true">더보기</danji-chip>
  * ```
  *
  * @prop isIcon - ChevronDown 아이콘 표시 여부

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
+import { useKakao } from 'vue3-kakao-maps/@utils'
 
 import './assets/styles/reset.css'
 import './assets/styles/tailwind.css'
@@ -13,6 +14,7 @@ if (import.meta.env.DEV) {
   await worker.start({ onUnhandledRequest: 'bypass' })
 }
 
+useKakao(import.meta.env.VITE_KAKAO_APP_API_KEY)
 const app = createApp(App)
 
 app.use(createPinia())

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -15,6 +15,7 @@ import CardChargePage from '@/views/wallet/charge/CardChargePage.vue'
 import ChargeCompletePage from '@/views/wallet/charge/ChargeCompletePage.vue'
 import { Component } from 'lucide-vue-next'
 import LocalCardCreateDetailPage from '@/views/wallet/create/LocalCardCreateDetailPage.vue'
+import MapPage from '@/views/map/MapPage.vue'
 
 const routes = [
   {
@@ -74,6 +75,10 @@ const routes = [
     path: '/wallet/card/create/:region/:city',
     name: 'LocalCardCreateDetail',
     component: LocalCardCreateDetailPage,
+  },
+  {
+    path: '/map',
+    component: MapPage,
   },
 ]
 

--- a/src/views/map/MapPage.vue
+++ b/src/views/map/MapPage.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { KakaoMap, KakaoMapMarker } from 'vue3-kakao-maps'
+import { Search, Plus, Minus, Crosshair } from 'lucide-vue-next'
+import DanjiChip from '@/components/common/chip/DanjiChip.vue'
+import DanjiChipGroup from '@/components/common/chip/DanjiChipGroup.vue'
+import { ref } from 'vue'
+import Layout from '@/components/layout/Layout.vue'
+
+const coordinate = {
+  lat: 33.450701,
+  lng: 126.570667,
+}
+
+const selectedFilter = ref<string>('전체')
+const mapLevel = ref(3)
+
+const zoomIn = () => {
+  mapLevel.value = Math.max(1, mapLevel.value - 1)
+}
+
+const zoomOut = () => {
+  mapLevel.value = Math.min(14, mapLevel.value + 1)
+}
+</script>
+
+<template>
+  <layout header-type="none" :is-bottom-nav="true">
+    <template #content>
+      <div class="flex flex-col h-full">
+        <!-- 검색창 -->
+        <div
+          class="flex mt-[1.6rem] mx-[1.6rem] px-[2.1rem] py-[0.8rem] bg-Gray-0 Body02 rounded-[2.5rem] border-2 border-Gray-1"
+        >
+          <search :size="20" color="#a3a3a3" :stroke-width="1.25" />
+          <input
+            placeholder="가맹점명, 주소를 검색하세요"
+            class="w-full ms-[1rem] bg-Gray-0 focus:outline-none focus:border-Gray-3 focus:ring-0 transition-colors"
+          />
+        </div>
+
+        <!-- 필터 -->
+        <div class="flex mx-[1.6rem] mt-[2.2rem]">
+          <danji-chip :is-icon="true" :is-active="true">강릉</danji-chip>
+          <danji-chip-group
+            :options="['전체', '음식점', '카페']"
+            v-model="selectedFilter"
+            class="ms-[1rem] me-[1rem]"
+          />
+        </div>
+
+        <!-- 카카오 맵 -->
+        <div class="flex-1 relative mt-[2.2rem]">
+          <kakao-map
+            :lat="coordinate.lat"
+            :lng="coordinate.lng"
+            :level="mapLevel"
+            :draggable="true"
+            width="100%"
+            height="100%"
+          >
+            <kakao-map-marker :lat="coordinate.lat" :lng="coordinate.lng"></kakao-map-marker>
+          </kakao-map>
+          <button
+            @click="zoomIn"
+            class="absolute top-[1.7rem] z-[1000] right-[1.6rem] p-[1.5rem] bg-white rounded-[0.8rem] shadow-lg"
+          >
+            <plus :size="15" />
+          </button>
+          <button
+            @click="zoomOut"
+            class="absolute top-[6.9rem] z-[1000] right-[1.6rem] p-[1.5rem] bg-white rounded-[0.8rem] shadow-lg"
+          >
+            <minus :size="15" />
+          </button>
+
+          <button
+            class="absolute bottom-[2rem] z-[1000] right-[1.6rem] p-[1.5rem] bg-white rounded-full shadow-lg"
+          >
+            <crosshair :size="15" color="#0062ff" />
+          </button>
+        </div>
+      </div>
+    </template>
+  </layout>
+</template>


### PR DESCRIPTION
## 📌 Issues
- closed #51 

## 🏁 Work Description
- 카카오맵 연동
- 지도 ui 구현

## 💬 PR Points
- 프로젝트 하위 .env 파일에 앱 키 추가해주셔야합니다! 노션 참고해주세요~!
```
VITE_KAKAO_APP_API_KEY=노션 값 참고
``` 

- 카카오 dev에 사이트 도메인을 등록해줘야 테스트 가능합니다! local은 등록해놨지만, 모바일은 개별적으로 ip가 달라서 따로 등록해줘야 해요! 필요하시면 말해주세요~

## 📷 Screenshot

https://github.com/user-attachments/assets/57db3213-4311-46e2-8652-13445f4a143a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 카카오 지도를 통합한 새로운 지도 페이지가 추가되었습니다. 지도에서 마커, 드래그, 줌 인/아웃, 검색 입력 및 카테고리별 필터(전체, 음식점, 카페) 기능을 사용할 수 있습니다.
  * `/map` 경로로 접근할 수 있는 새로운 라우트가 추가되었습니다.

* **문서**
  * Chip 컴포넌트 예제의 prop 명명 방식을 Vue 템플릿 규칙에 맞게 수정했습니다.

* **기타**
  * 카카오 지도 연동을 위한 외부 라이브러리(`vue3-kakao-maps`)가 추가되었습니다.
  * 환경 변수 타입 선언이 추가되어 카카오 API 키 접근이 타입 안전하게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->