### PR TITLE
[Feature/scrum 126] : badge UI 구현

### DIFF
--- a/src/components/badge/BadgeCollectionContainer.vue
+++ b/src/components/badge/BadgeCollectionContainer.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+let badgeCount = 5
+</script>
+<template>
+  <section class="flex flex-col w-full">
+    <!-- 뱃지 종류 선택 버튼 -->
+    <div class="flex justify-between h-[2.9rem] Head04 text-White-0">
+      <button class="w-full rounded-tl-[1rem] bg-Yellow-0">지역</button>
+      <button class="w-full rounded-tr-[1rem] bg-Yellow-0/20">스페셜</button>
+    </div>
+    <!-- 뱃지 내용 부분 -->
+    <div
+      class="flex flex-col justify-center items-center w-full h-[32.3rem] gap-[2.5rem] rounded-b-[1.6rem] bg-White-0"
+    >
+      <div class="flex justify-between w-[31.7rem] Body01">
+        <span>내가 모은 뱃지를 확인해보세요</span><span>총 {{ badgeCount }}개</span>
+      </div>
+      <!-- 뱃지 리스트 아이템 -->
+      <div
+        class="flex flex-col justify-center items-center w-[31.7rem] h-[9.4rem] text-Gray-8 Head03 border-solid border-[0.2rem] border-Gray-1 rounded-[1.6rem]"
+      >
+        <span class="relative top-[-17%] bg-White-0">행운의 감자</span>
+        <div class="flex justify-between">
+          <img src="" alt="" class="w-[6rem] h-[6rem]" />
+          <img src="" alt="" class="w-[6rem] h-[6rem]" />
+          <img src="" alt="" class="w-[6rem] h-[6rem]" />
+        </div>
+      </div>
+      <!-- 뱃지 리스트 아이템 -->
+      <div
+        class="flex flex-col justify-center items-center w-[31.7rem] h-[9.4rem] text-Gray-8 Head03 border-solid border-[0.2rem] border-Gray-1 rounded-[1.6rem]"
+      >
+        <span class="relative top-[-17%] bg-White-0">돌하르방의 청혼</span>
+        <div class="flex justify-between">
+          <img src="" alt="" class="w-[6rem] h-[6rem]" />
+          <img src="" alt="" class="w-[6rem] h-[6rem]" />
+          <img src="" alt="" class="w-[6rem] h-[6rem]" />
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+<style scoped></style>

--- a/src/components/badge/BadgeCollectionContainer.vue
+++ b/src/components/badge/BadgeCollectionContainer.vue
@@ -17,10 +17,10 @@ let badgeCount = 5
       </div>
       <!-- 뱃지 리스트 아이템 -->
       <div
-        class="flex flex-col justify-center items-center w-[31.7rem] h-[9.4rem] text-Gray-8 Head03 border-solid border-[0.2rem] border-Gray-1 rounded-[1.6rem]"
+        class="relative flex flex-col justify-center items-center w-[31.7rem] h-[9.7rem] text-Gray-8 Head03 border-solid border-[0.2rem] border-Gray-1 rounded-[1.6rem]"
       >
-        <span class="relative top-[-17%] bg-White-0">행운의 감자</span>
-        <div class="flex justify-between">
+        <span class="absolute top-[-13%] bg-White-0">행운의 감자</span>
+        <div class="flex justify-between items-center px-[2.2rem] w-full">
           <img src="" alt="" class="w-[6rem] h-[6rem]" />
           <img src="" alt="" class="w-[6rem] h-[6rem]" />
           <img src="" alt="" class="w-[6rem] h-[6rem]" />
@@ -28,10 +28,10 @@ let badgeCount = 5
       </div>
       <!-- 뱃지 리스트 아이템 -->
       <div
-        class="flex flex-col justify-center items-center w-[31.7rem] h-[9.4rem] text-Gray-8 Head03 border-solid border-[0.2rem] border-Gray-1 rounded-[1.6rem]"
+        class="relative flex flex-col justify-center items-center w-[31.7rem] h-[9.7rem] text-Gray-8 Head03 border-solid border-[0.2rem] border-Gray-1 rounded-[1.6rem]"
       >
-        <span class="relative top-[-17%] bg-White-0">돌하르방의 청혼</span>
-        <div class="flex justify-between">
+        <span class="absolute top-[-13%] bg-White-0">돌하르방의 청혼</span>
+        <div class="flex justify-between items-center px-[2.2rem] w-full">
           <img src="" alt="" class="w-[6rem] h-[6rem]" />
           <img src="" alt="" class="w-[6rem] h-[6rem]" />
           <img src="" alt="" class="w-[6rem] h-[6rem]" />

--- a/src/components/badge/BadgeCollectionContainer.vue
+++ b/src/components/badge/BadgeCollectionContainer.vue
@@ -2,6 +2,7 @@
 import { ref, computed } from 'vue'
 import type { BadgeCategoryType } from '@/types/badge'
 import LocalBadgeCollection from '@/components/badge/LocalBadgeCollection.vue'
+import SpecialBadgeCollection from '@/components/badge/SpecialBadgeCollection.vue'
 
 let category = ref<BadgeCategoryType>('지역')
 
@@ -22,13 +23,43 @@ const regionBadges = [
 const specialBadges = [
   {
     id: 3,
-    name: '황금 물결',
-    images: ['special1.jpg', 'special2.jpg', 'special3.jpg'],
+    name: '부산',
+    images: 'special1.jpg',
   },
   {
     id: 4,
-    name: '다이아몬드 노래',
-    images: ['special4.jpg', 'special5.jpg', 'special6.jpg'],
+    name: '양산',
+    images: 'special6.jpg',
+  },
+  {
+    id: 5,
+    name: '양양',
+    images: 'special1.jpg',
+  },
+  {
+    id: 6,
+    name: '독도',
+    images: 'special6.jpg',
+  },
+  {
+    id: 5,
+    name: '전주',
+    images: 'special1.jpg',
+  },
+  {
+    id: 6,
+    name: '인천',
+    images: 'special6.jpg',
+  },
+  {
+    id: 5,
+    name: '울릉도',
+    images: 'special1.jpg',
+  },
+  {
+    id: 6,
+    name: '여수',
+    images: 'special6.jpg',
   },
 ]
 
@@ -74,11 +105,15 @@ const changeCategory = (newCategory: BadgeCategoryType) => {
     <div
       class="flex flex-col justify-center items-center w-full h-[32.3rem] pt-[1.4rem] gap-[2.5rem] rounded-b-[1.6rem] bg-White-0"
     >
-      <local-badge-collection
-        :badge-count="badgeCount"
-        :category="category"
-        :badges="currentBadges"
-      />
+      <div class="flex-1 overflow-y-auto flex flex-col items-center justify-center w-full h-full">
+        <!-- 지역 뱃지 내용 섹션 -->
+        <div class="flex justify-between w-[31.7rem] mb-[2rem] Body01">
+          <span>내가 모은 뱃지를 확인해보세요</span><span>총 {{ badgeCount }}개</span>
+        </div>
+        <local-badge-collection v-if="category === '지역'" :badges="regionBadges" />
+        <special-badge-collection v-if="category === '스페셜'" :badges="specialBadges" />
+      </div>
+
       <!-- 뱃지가 없을 때 표시할 내용 -->
       <div
         v-if="currentBadges.length === 0"

--- a/src/components/badge/BadgeCollectionContainer.vue
+++ b/src/components/badge/BadgeCollectionContainer.vue
@@ -1,41 +1,91 @@
 <script setup lang="ts">
-let badgeCount = 5
+import { ref, computed } from 'vue'
+import type { BadgeCategoryType } from '@/types/badge'
+import LocalBadgeCollection from '@/components/badge/LocalBadgeCollection.vue'
+
+let category = ref<BadgeCategoryType>('지역')
+
+// 카테고리별 뱃지 임시 mock 데이터
+const regionBadges = [
+  {
+    id: 1,
+    name: '행운의 감자',
+    images: ['img1.jpg', 'img2.jpg', 'img3.jpg'],
+  },
+  {
+    id: 2,
+    name: '돌하르방의 청혼',
+    images: ['img4.jpg', 'img5.jpg', 'img6.jpg'],
+  },
+]
+
+const specialBadges = [
+  {
+    id: 3,
+    name: '황금 물결',
+    images: ['special1.jpg', 'special2.jpg', 'special3.jpg'],
+  },
+  {
+    id: 4,
+    name: '다이아몬드 노래',
+    images: ['special4.jpg', 'special5.jpg', 'special6.jpg'],
+  },
+]
+
+// 현재 카테고리에 따른 뱃지 목록
+const currentBadges = computed(() => {
+  return category.value === '지역' ? regionBadges : specialBadges
+})
+
+// 현재 카테고리에 따른 뱃지 개수
+const badgeCount = computed(() => {
+  return currentBadges.value.length
+})
+
+// 카테고리 변경 함수
+const changeCategory = (newCategory: BadgeCategoryType) => {
+  category.value = newCategory
+}
 </script>
 <template>
-  <section class="flex flex-col w-full">
+  <section class="flex flex-col w-full h-[32.3rem]">
     <!-- 뱃지 종류 선택 버튼 -->
     <div class="flex justify-between h-[2.9rem] Head04 text-White-0">
-      <button class="w-full rounded-tl-[1rem] bg-Yellow-0">지역</button>
-      <button class="w-full rounded-tr-[1rem] bg-Yellow-0/20">스페셜</button>
+      <button
+        @click="changeCategory('지역')"
+        :class="[
+          'w-full rounded-tl-[1rem] transition-colors',
+          category === '지역' ? 'bg-Yellow-0' : 'bg-Yellow-0/20',
+        ]"
+      >
+        지역
+      </button>
+      <button
+        @click="changeCategory('스페셜')"
+        :class="[
+          'w-full rounded-tr-[1rem] transition-colors',
+          category === '스페셜' ? 'bg-Yellow-0' : 'bg-Yellow-0/20',
+        ]"
+      >
+        스페셜
+      </button>
     </div>
     <!-- 뱃지 내용 부분 -->
     <div
-      class="flex flex-col justify-center items-center w-full h-[32.3rem] gap-[2.5rem] rounded-b-[1.6rem] bg-White-0"
+      class="flex flex-col justify-center items-center w-full h-[32.3rem] pt-[1.4rem] gap-[2.5rem] rounded-b-[1.6rem] bg-White-0"
     >
-      <div class="flex justify-between w-[31.7rem] Body01">
-        <span>내가 모은 뱃지를 확인해보세요</span><span>총 {{ badgeCount }}개</span>
-      </div>
-      <!-- 뱃지 리스트 아이템 -->
+      <local-badge-collection
+        :badge-count="badgeCount"
+        :category="category"
+        :badges="currentBadges"
+      />
+      <!-- 뱃지가 없을 때 표시할 내용 -->
       <div
-        class="relative flex flex-col justify-center items-center w-[31.7rem] h-[9.7rem] text-Gray-8 Head03 border-solid border-[0.2rem] border-Gray-1 rounded-[1.6rem]"
+        v-if="currentBadges.length === 0"
+        class="flex flex-col items-center justify-center h-[15rem] text-Gray-5 Body02"
       >
-        <span class="absolute top-[-13%] bg-White-0">행운의 감자</span>
-        <div class="flex justify-between items-center px-[2.2rem] w-full">
-          <img src="" alt="" class="w-[6rem] h-[6rem]" />
-          <img src="" alt="" class="w-[6rem] h-[6rem]" />
-          <img src="" alt="" class="w-[6rem] h-[6rem]" />
-        </div>
-      </div>
-      <!-- 뱃지 리스트 아이템 -->
-      <div
-        class="relative flex flex-col justify-center items-center w-[31.7rem] h-[9.7rem] text-Gray-8 Head03 border-solid border-[0.2rem] border-Gray-1 rounded-[1.6rem]"
-      >
-        <span class="absolute top-[-13%] bg-White-0">돌하르방의 청혼</span>
-        <div class="flex justify-between items-center px-[2.2rem] w-full">
-          <img src="" alt="" class="w-[6rem] h-[6rem]" />
-          <img src="" alt="" class="w-[6rem] h-[6rem]" />
-          <img src="" alt="" class="w-[6rem] h-[6rem]" />
-        </div>
+        <span>아직 {{ category }} 뱃지가 없습니다</span>
+        <span>더 많은 활동으로 뱃지를 획득해보세요!</span>
       </div>
     </div>
   </section>

--- a/src/components/badge/BadgeCollectionContainer.vue
+++ b/src/components/badge/BadgeCollectionContainer.vue
@@ -1,127 +1,22 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
-import type { BadgeCategoryType } from '@/types/badge'
-import LocalBadgeCollection from '@/components/badge/LocalBadgeCollection.vue'
-import SpecialBadgeCollection from '@/components/badge/SpecialBadgeCollection.vue'
+import { provideBadgeCollection } from '@/composables/badge/useBadgeCollection'
+import BadgeCollectionTabs from '@/components/badge/BadgeCollectionTabs.vue'
+import BadgeCollectionContents from '@/components/badge/BadgeCollectionContents.vue'
+import BadgeDetail from '@/components/badge/BadgeDetail.vue'
 
-let category = ref<BadgeCategoryType>('지역')
-
-// 카테고리별 뱃지 임시 mock 데이터
-const regionBadges = [
-  {
-    id: 1,
-    name: '행운의 감자',
-    images: ['img1.jpg', 'img2.jpg', 'img3.jpg'],
-  },
-  {
-    id: 2,
-    name: '돌하르방의 청혼',
-    images: ['img4.jpg', 'img5.jpg', 'img6.jpg'],
-  },
-]
-
-const specialBadges = [
-  {
-    id: 3,
-    name: '부산',
-    images: 'special1.jpg',
-  },
-  {
-    id: 4,
-    name: '양산',
-    images: 'special6.jpg',
-  },
-  {
-    id: 5,
-    name: '양양',
-    images: 'special1.jpg',
-  },
-  {
-    id: 6,
-    name: '독도',
-    images: 'special6.jpg',
-  },
-  {
-    id: 5,
-    name: '전주',
-    images: 'special1.jpg',
-  },
-  {
-    id: 6,
-    name: '인천',
-    images: 'special6.jpg',
-  },
-  {
-    id: 5,
-    name: '울릉도',
-    images: 'special1.jpg',
-  },
-  {
-    id: 6,
-    name: '여수',
-    images: 'special6.jpg',
-  },
-]
-
-// 현재 카테고리에 따른 뱃지 목록
-const currentBadges = computed(() => {
-  return category.value === '지역' ? regionBadges : specialBadges
-})
-
-// 현재 카테고리에 따른 뱃지 개수
-const badgeCount = computed(() => {
-  return currentBadges.value.length
-})
-
-// 카테고리 변경 함수
-const changeCategory = (newCategory: BadgeCategoryType) => {
-  category.value = newCategory
-}
+const { showBadgeDetail } = provideBadgeCollection()
 </script>
 <template>
   <section class="flex flex-col w-full h-[32.3rem]">
     <!-- 뱃지 종류 선택 버튼 -->
-    <div class="flex justify-between h-[2.9rem] Head04 text-White-0">
-      <button
-        @click="changeCategory('지역')"
-        :class="[
-          'w-full rounded-tl-[1rem] transition-colors',
-          category === '지역' ? 'bg-Yellow-0' : 'bg-Yellow-0/20',
-        ]"
-      >
-        지역
-      </button>
-      <button
-        @click="changeCategory('스페셜')"
-        :class="[
-          'w-full rounded-tr-[1rem] transition-colors',
-          category === '스페셜' ? 'bg-Yellow-0' : 'bg-Yellow-0/20',
-        ]"
-      >
-        스페셜
-      </button>
-    </div>
+    <badge-collection-tabs />
     <!-- 뱃지 내용 부분 -->
     <div
       class="flex flex-col justify-center items-center w-full h-[32.3rem] pt-[1.4rem] gap-[2.5rem] rounded-b-[1.6rem] bg-White-0"
     >
-      <div class="flex-1 overflow-y-auto flex flex-col items-center justify-center w-full h-full">
-        <!-- 지역 뱃지 내용 섹션 -->
-        <div class="flex justify-between w-[31.7rem] mb-[2rem] Body01">
-          <span>내가 모은 뱃지를 확인해보세요</span><span>총 {{ badgeCount }}개</span>
-        </div>
-        <local-badge-collection v-if="category === '지역'" :badges="regionBadges" />
-        <special-badge-collection v-if="category === '스페셜'" :badges="specialBadges" />
-      </div>
-
-      <!-- 뱃지가 없을 때 표시할 내용 -->
-      <div
-        v-if="currentBadges.length === 0"
-        class="flex flex-col items-center justify-center h-[15rem] text-Gray-5 Body02"
-      >
-        <span>아직 {{ category }} 뱃지가 없습니다</span>
-        <span>더 많은 활동으로 뱃지를 획득해보세요!</span>
-      </div>
+      <!-- 뱃지 상세 화면 -->
+      <badge-detail v-if="showBadgeDetail" />
+      <badge-collection-contents v-else />
     </div>
   </section>
 </template>

--- a/src/components/badge/BadgeCollectionContents.vue
+++ b/src/components/badge/BadgeCollectionContents.vue
@@ -11,7 +11,7 @@ const currentBadges = computed(() => (category.value === '지역' ? regionBadges
 const badgeCount = computed(() => currentBadges.value.length)
 </script>
 <template>
-  <div class="flex-1 overflow-y-auto flex flex-col items-center w-full h-full">
+  <div class="flex-1 overflow-y-auto flex flex-col items-center w-full h-[35.2rem]">
     <!-- 상단 정보 -->
     <div class="flex justify-between w-[31.7rem] mb-[2rem] Body01">
       <span>내가 모은 뱃지를 확인해보세요</span>

--- a/src/components/badge/BadgeCollectionContents.vue
+++ b/src/components/badge/BadgeCollectionContents.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useBadgeCollection } from '@/composables/badge/useBadgeCollection'
+import LocalBadgeCollection from '@/components/badge/LocalBadgeCollection.vue'
+import SpecialBadgeCollection from '@/components/badge/SpecialBadgeCollection.vue'
+
+// 추후 수정 예정(카테고리에 맞는 뱃지만 렌더링할 수 있도록)
+const { category, regionBadges, specialBadges } = useBadgeCollection()
+
+const currentBadges = computed(() => (category.value === '지역' ? regionBadges : specialBadges))
+const badgeCount = computed(() => currentBadges.value.length)
+</script>
+<template>
+  <div class="flex-1 overflow-y-auto flex flex-col items-center w-full h-full">
+    <!-- 상단 정보 -->
+    <div class="flex justify-between w-[31.7rem] mb-[2rem] Body01">
+      <span>내가 모은 뱃지를 확인해보세요</span>
+      <span>총 {{ badgeCount }}개</span>
+    </div>
+
+    <!-- 뱃지 목록 -->
+    <local-badge-collection v-if="category === '지역'" />
+    <special-badge-collection v-if="category === '스페셜'" />
+
+    <!-- 뱃지 없을 때 -->
+    <div
+      v-if="currentBadges.length === 0"
+      class="flex flex-col items-center justify-center h-[15rem] text-Gray-5 Body02"
+    >
+      <span>아직 {{ category }} 뱃지가 없습니다</span>
+      <span>더 많은 활동으로 뱃지를 획득해보세요!</span>
+    </div>
+  </div>
+</template>
+<style scoped></style>

--- a/src/components/badge/BadgeCollectionTabs.vue
+++ b/src/components/badge/BadgeCollectionTabs.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { useBadgeCollection } from '@/composables/badge/useBadgeCollection'
+
+const { category, changeCategory } = useBadgeCollection()
+</script>
+<template>
+  <div class="flex justify-between h-[2.9rem] Head04 text-White-0">
+    <button
+      @click="changeCategory('지역')"
+      :class="[
+        'w-full rounded-tl-[1rem] transition-colors',
+        category === '지역' ? 'bg-Yellow-0' : 'bg-Yellow-0/20',
+      ]"
+    >
+      지역
+    </button>
+    <button
+      @click="changeCategory('스페셜')"
+      :class="[
+        'w-full rounded-tr-[1rem] transition-colors',
+        category === '스페셜' ? 'bg-Yellow-0' : 'bg-Yellow-0/20',
+      ]"
+    >
+      스페셜
+    </button>
+  </div>
+</template>
+<style scoped></style>

--- a/src/components/badge/BadgeCollectionTabs.vue
+++ b/src/components/badge/BadgeCollectionTabs.vue
@@ -8,7 +8,7 @@ const { category, changeCategory } = useBadgeCollection()
     <button
       @click="changeCategory('지역')"
       :class="[
-        'w-full rounded-tl-[1rem] transition-colors',
+        'w-full h-[2.9rem] rounded-tl-[1rem] transition-colors',
         category === '지역' ? 'bg-Yellow-0' : 'bg-Yellow-0/20',
       ]"
     >
@@ -17,7 +17,7 @@ const { category, changeCategory } = useBadgeCollection()
     <button
       @click="changeCategory('스페셜')"
       :class="[
-        'w-full rounded-tr-[1rem] transition-colors',
+        'w-full h-[2.9rem] rounded-tr-[1rem] transition-colors',
         category === '스페셜' ? 'bg-Yellow-0' : 'bg-Yellow-0/20',
       ]"
     >

--- a/src/components/badge/BadgeDetail.vue
+++ b/src/components/badge/BadgeDetail.vue
@@ -4,7 +4,7 @@ import { useBadgeCollection } from '@/composables/badge/useBadgeCollection'
 const { selectedBadge } = useBadgeCollection()
 </script>
 <template>
-  <div class="flex flex-col">
+  <div class="flex flex-col w-full h-[32.3rem] justify-center items-center">
     <!-- 뱃지 코멘트 -->
     <div class="flex flex-col justify-center items-center mb-[0.5rem] Body02 text-Gray-4">
       <span>{{ selectedBadge.comment }}</span>
@@ -19,7 +19,7 @@ const { selectedBadge } = useBadgeCollection()
       />
     </div>
     <div
-      :key="selectedBadge.id"
+      :key="selectedBadge.badge_id"
       class="relative flex flex-col justify-center items-center w-[31.7rem] h-[9.7rem] mb-[2.5rem] text-Gray-8 Head03 border-solid border-[0.2rem] border-Gray-1 rounded-[1.6rem]"
     >
       <span class="absolute top-[-13%] bg-White-0">{{ selectedBadge.name }}</span>

--- a/src/components/badge/BadgeDetail.vue
+++ b/src/components/badge/BadgeDetail.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { useBadgeCollection } from '@/composables/badge/useBadgeCollection'
+
+const { selectedBadge } = useBadgeCollection()
+</script>
+<template>
+  <div class="flex flex-col">
+    <!-- 뱃지 코멘트 -->
+    <div class="flex flex-col justify-center items-center mb-[0.5rem] Body02 text-Gray-4">
+      <span>{{ selectedBadge.comment }}</span>
+    </div>
+
+    <!-- 뱃지 이미지 -->
+    <div class="flex justify-center items-center mb-[1.5rem]">
+      <img
+        :src="selectedBadge.image"
+        :alt="`${selectedBadge.name} 뱃지`"
+        class="w-[15.4rem] h-[15.4rem] bg-Gray-1"
+      />
+    </div>
+    <div
+      :key="selectedBadge.id"
+      class="relative flex flex-col justify-center items-center w-[31.7rem] h-[9.7rem] mb-[2.5rem] text-Gray-8 Head03 border-solid border-[0.2rem] border-Gray-1 rounded-[1.6rem]"
+    >
+      <span class="absolute top-[-13%] bg-White-0">{{ selectedBadge.name }}</span>
+
+      <span
+        class="flex justify-center items-center px-[7rem] text-center flex-wrap Body01 text-Black-0 break-keep"
+        >{{ selectedBadge.region_id }} 지역화폐 사용 금액이 20만 원을 넘은 당신에게 주어지는 가장
+        빛나는 사랑의 증표입니다.🥇</span
+      >
+    </div>
+  </div>
+</template>
+<style scoped></style>

--- a/src/components/badge/BadgePageInfo.vue
+++ b/src/components/badge/BadgePageInfo.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts"></script>
+<template>
+  <div
+    class="flex flex-col justify-center items-center w-full h-[6.7rem] mb-[2.5rem] rounded-[1.6rem] bg-White-0 Body01"
+  >
+    <span
+      >당신의 지역화폐 사용 이력이 <span class="text-Yellow-0">특별한 뱃지</span>로
+      기록됩니다.</span
+    ><br />
+    <span>많이 쓸수록 더 반짝이는 뱃지를 만나보세요!</span>
+  </div>
+</template>
+<style scoped></style>

--- a/src/components/badge/BadgePageInfo.vue
+++ b/src/components/badge/BadgePageInfo.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts"></script>
 <template>
   <div
-    class="flex flex-col justify-center items-center w-full h-[6.7rem] mb-[2.5rem] rounded-[1.6rem] bg-White-0 Body01"
+    class="flex flex-col justify-center items-center w-full h-[6.7rem] mt-[1rem] mb-[2.1rem] rounded-[1.6rem] bg-White-0 Body01"
   >
     <span
       >당신의 지역화폐 사용 이력이 <span class="text-Yellow-0">특별한 뱃지</span>로

--- a/src/components/badge/LocalBadgeCollection.vue
+++ b/src/components/badge/LocalBadgeCollection.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import type { BadgeCategoryType } from '@/types/badge'
+
+interface LocalBadgeProps {
+  badgeCount: number
+  category: BadgeCategoryType
+  badges: Array<{
+    id: number
+    name: string
+    images: string[]
+  }>
+}
+
+const props = defineProps<LocalBadgeProps>()
+</script>
+<template>
+  <div class="flex-1 overflow-y-auto flex flex-col items-center justify-center w-full h-full">
+    <!-- 지역 뱃지 내용 섹션 -->
+    <div class="flex justify-between w-[31.7rem] mb-[2rem] Body01">
+      <span>내가 모은 뱃지를 확인해보세요</span><span>총 {{ props.badgeCount }}개</span>
+    </div>
+    <!-- 뱃지 리스트 아이템 -->
+    <div
+      v-for="badge in props.badges"
+      :key="badge.id"
+      class="relative flex flex-col justify-center items-center w-[31.7rem] h-[9.7rem] mb-[2.5rem] text-Gray-8 Head03 border-solid border-[0.2rem] border-Gray-1 rounded-[1.6rem]"
+    >
+      <span class="absolute top-[-13%] bg-White-0">{{ badge.name }}</span>
+      <div class="flex justify-between items-center px-[2.2rem] w-full">
+        <img
+          v-for="(image, index) in badge.images"
+          :key="index"
+          :src="image"
+          :alt="`${badge.name} 뱃지 ${index + 1}`"
+          class="w-[6rem] h-[6rem] bg-Gray-1"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+<style scoped></style>

--- a/src/components/badge/LocalBadgeCollection.vue
+++ b/src/components/badge/LocalBadgeCollection.vue
@@ -1,30 +1,22 @@
 <script setup lang="ts">
-import type { BadgeCategoryType } from '@/types/badge'
+import { useBadgeCollection } from '@/composables/badge/useBadgeCollection'
 
-interface LocalBadgeProps {
-  badges: Array<{
-    id: number
-    name: string
-    images: string[]
-  }>
-}
-
-const props = defineProps<LocalBadgeProps>()
+const { currentBadges, handleBadgeClick } = useBadgeCollection()
 </script>
 <template>
   <!-- 뱃지 리스트 아이템 -->
   <div
-    v-for="badge in props.badges"
-    :key="badge.id"
+    v-for="badge in currentBadges"
+    :key="badge.badge_id"
     class="relative flex flex-col justify-center items-center w-[31.7rem] h-[9.7rem] mb-[2.5rem] text-Gray-8 Head03 border-solid border-[0.2rem] border-Gray-1 rounded-[1.6rem]"
+    @click="handleBadgeClick(badge)"
   >
     <span class="absolute top-[-13%] bg-White-0">{{ badge.name }}</span>
     <div class="flex justify-between items-center px-[2.2rem] w-full">
       <img
-        v-for="(image, index) in badge.images"
-        :key="index"
-        :src="image"
-        :alt="`${badge.name} 뱃지 ${index + 1}`"
+        :key="badge.index"
+        :src="badge.image"
+        :alt="`${badge.name} 뱃지 ${badge.index + 1}`"
         class="w-[6rem] h-[6rem] bg-Gray-1"
       />
     </div>

--- a/src/components/badge/LocalBadgeCollection.vue
+++ b/src/components/badge/LocalBadgeCollection.vue
@@ -2,8 +2,6 @@
 import type { BadgeCategoryType } from '@/types/badge'
 
 interface LocalBadgeProps {
-  badgeCount: number
-  category: BadgeCategoryType
   badges: Array<{
     id: number
     name: string
@@ -14,27 +12,21 @@ interface LocalBadgeProps {
 const props = defineProps<LocalBadgeProps>()
 </script>
 <template>
-  <div class="flex-1 overflow-y-auto flex flex-col items-center justify-center w-full h-full">
-    <!-- 지역 뱃지 내용 섹션 -->
-    <div class="flex justify-between w-[31.7rem] mb-[2rem] Body01">
-      <span>내가 모은 뱃지를 확인해보세요</span><span>총 {{ props.badgeCount }}개</span>
-    </div>
-    <!-- 뱃지 리스트 아이템 -->
-    <div
-      v-for="badge in props.badges"
-      :key="badge.id"
-      class="relative flex flex-col justify-center items-center w-[31.7rem] h-[9.7rem] mb-[2.5rem] text-Gray-8 Head03 border-solid border-[0.2rem] border-Gray-1 rounded-[1.6rem]"
-    >
-      <span class="absolute top-[-13%] bg-White-0">{{ badge.name }}</span>
-      <div class="flex justify-between items-center px-[2.2rem] w-full">
-        <img
-          v-for="(image, index) in badge.images"
-          :key="index"
-          :src="image"
-          :alt="`${badge.name} 뱃지 ${index + 1}`"
-          class="w-[6rem] h-[6rem] bg-Gray-1"
-        />
-      </div>
+  <!-- 뱃지 리스트 아이템 -->
+  <div
+    v-for="badge in props.badges"
+    :key="badge.id"
+    class="relative flex flex-col justify-center items-center w-[31.7rem] h-[9.7rem] mb-[2.5rem] text-Gray-8 Head03 border-solid border-[0.2rem] border-Gray-1 rounded-[1.6rem]"
+  >
+    <span class="absolute top-[-13%] bg-White-0">{{ badge.name }}</span>
+    <div class="flex justify-between items-center px-[2.2rem] w-full">
+      <img
+        v-for="(image, index) in badge.images"
+        :key="index"
+        :src="image"
+        :alt="`${badge.name} 뱃지 ${index + 1}`"
+        class="w-[6rem] h-[6rem] bg-Gray-1"
+      />
     </div>
   </div>
 </template>

--- a/src/components/badge/SpecialBadgeCollection.vue
+++ b/src/components/badge/SpecialBadgeCollection.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+interface SpecialBadgeProps {
+  badges: Array<{
+    id: number
+    name: string
+    images: string
+  }>
+}
+
+const props = defineProps<SpecialBadgeProps>()
+</script>
+<template>
+  <!-- 뱃지 리스트 아이템 -->
+  <div class="flex w-full h-full justify-center items-start flex-wrap gap-[1.3rem]">
+    <div
+      v-for="badge in props.badges"
+      :key="badge.id"
+      class="flex flex-col justify-center items-center"
+    >
+      <img
+        :key="badge.id"
+        :src="badge.images"
+        :alt="`${badge.name} 뱃지 ${badge.id + 1}`"
+        class="w-[7rem] h-[7rem] bg-Gray-0"
+      />
+      <span class="Body01">{{ badge.name }}</span>
+    </div>
+  </div>
+</template>
+<style scoped></style>

--- a/src/components/badge/SpecialBadgeCollection.vue
+++ b/src/components/badge/SpecialBadgeCollection.vue
@@ -1,21 +1,16 @@
 <script setup lang="ts">
-interface SpecialBadgeProps {
-  badges: Array<{
-    id: number
-    name: string
-    images: string
-  }>
-}
+import { useBadgeCollection } from '@/composables/badge/useBadgeCollection'
 
-const props = defineProps<SpecialBadgeProps>()
+const { currentBadges, handleBadgeClick } = useBadgeCollection()
 </script>
 <template>
   <!-- 뱃지 리스트 아이템 -->
   <div class="flex w-full h-full justify-center items-start flex-wrap gap-[1.3rem]">
     <div
-      v-for="badge in props.badges"
+      v-for="badge in currentBadges"
       :key="badge.id"
       class="flex flex-col justify-center items-center"
+      @click="handleBadgeClick(badge)"
     >
       <img
         :key="badge.id"

--- a/src/components/badge/SpecialBadgeCollection.vue
+++ b/src/components/badge/SpecialBadgeCollection.vue
@@ -8,14 +8,14 @@ const { currentBadges, handleBadgeClick } = useBadgeCollection()
   <div class="flex w-full h-full justify-center items-start flex-wrap gap-[1.3rem]">
     <div
       v-for="badge in currentBadges"
-      :key="badge.id"
+      :key="badge.badge_id"
       class="flex flex-col justify-center items-center"
       @click="handleBadgeClick(badge)"
     >
       <img
-        :key="badge.id"
+        :key="badge.badge_id"
         :src="badge.images"
-        :alt="`${badge.name} 뱃지 ${badge.id + 1}`"
+        :alt="`${badge.name} 뱃지 ${badge.badge_id + 1}`"
         class="w-[7rem] h-[7rem] bg-Gray-0"
       />
       <span class="Body01">{{ badge.name }}</span>

--- a/src/components/layout/Layout.vue
+++ b/src/components/layout/Layout.vue
@@ -93,7 +93,7 @@ const router = useRouter()
     />
 
     <!-- 메인 콘텐츠 영역 (페이지별 컴포넌트가 들어갈 곳) -->
-    <section class="flex-1 overflow-auto w-full h-full">
+    <section class="flex-1 overflow-auto w-full h-full bg-Gray-1">
       <slot name="content">
         <!-- 기본 fallback 콘텐츠 -->
         <div class="w-full h-full p-4 text-center text-Gray-5 bg-Gray-1">

--- a/src/components/layout/Layout.vue
+++ b/src/components/layout/Layout.vue
@@ -93,12 +93,10 @@ const router = useRouter()
     />
 
     <!-- 메인 콘텐츠 영역 (페이지별 컴포넌트가 들어갈 곳) -->
-    <section class="flex-1 overflow-auto w-full h-full bg-Gray-1">
+    <section class="flex-1 overflow-auto w-full h-full bg-Gray-0">
       <slot name="content">
         <!-- 기본 fallback 콘텐츠 -->
-        <div class="w-full h-full p-4 text-center text-Gray-5 bg-Gray-1">
-          페이지 콘텐츠를 추가해주세요
-        </div>
+        <div class="w-full h-full p-4 text-center text-Gray-5">페이지 콘텐츠를 추가해주세요</div>
       </slot>
     </section>
 

--- a/src/composables/badge/useBadgeCollection.ts
+++ b/src/composables/badge/useBadgeCollection.ts
@@ -1,0 +1,145 @@
+import { ref, computed, provide, inject, readonly } from 'vue'
+import type { InjectionKey } from 'vue'
+import type { BadgeType } from '@/types/badge'
+import type { BadgeCategoryType, Badge, BadgeCollection } from '@/types/badge'
+
+const BADGE_COLLECTION_KEY: InjectionKey<BadgeCollection> = Symbol('badge-collection')
+
+export function provideBadgeCollection(): BadgeCollection {
+  const category = ref<BadgeCategoryType>('지역')
+  const selectedBadge = ref<Badge | null>(null)
+  const showBadgeDetail = ref(false)
+
+  // 카테고리별 뱃지 임시 mock 데이터
+  const regionBadges: Badge[] = [
+    {
+      badge_id: '1',
+      name: '행운의 감자',
+      image: 'img1.jpg',
+      badge_type: '지역' as BadgeType,
+      region_id: 1,
+      comment: '행운의 감자 뱃지입니다',
+    },
+    {
+      badge_id: '2',
+      name: '돌하르방의 청혼',
+      image: 'img4.jpg',
+      badge_type: '지역' as BadgeType,
+      region_id: 2,
+      comment: '돌하르방의 청혼 뱃지입니다',
+    },
+  ]
+
+  const specialBadges: Badge[] = [
+    {
+      badge_id: '3',
+      name: '부산',
+      image: 'special1.jpg',
+      badge_type: '스페셜' as BadgeType,
+      region_id: 3,
+      comment: '부산 스페셜 뱃지입니다',
+    },
+    {
+      badge_id: '4',
+      name: '양산',
+      image: 'special6.jpg',
+      badge_type: '스페셜' as BadgeType,
+      region_id: 4,
+      comment: '양산 스페셜 뱃지입니다',
+    },
+    {
+      badge_id: '5',
+      name: '양양',
+      image: 'special1.jpg',
+      badge_type: '스페셜' as BadgeType,
+      region_id: 5,
+      comment: '양양 스페셜 뱃지입니다',
+    },
+    {
+      badge_id: '6',
+      name: '독도',
+      image: 'special6.jpg',
+      badge_type: '스페셜' as BadgeType,
+      region_id: 6,
+      comment: '독도 스페셜 뱃지입니다',
+    },
+    {
+      badge_id: '7',
+      name: '전주',
+      image: 'special1.jpg',
+      badge_type: '스페셜' as BadgeType,
+      region_id: 7,
+      comment: '전주 스페셜 뱃지입니다',
+    },
+    {
+      badge_id: '8',
+      name: '인천',
+      image: 'special6.jpg',
+      badge_type: '스페셜' as BadgeType,
+      region_id: 8,
+      comment: '인천 스페셜 뱃지입니다',
+    },
+    {
+      badge_id: '9',
+      name: '울릉도',
+      image: 'special1.jpg',
+      badge_type: '스페셜' as BadgeType,
+      region_id: 9,
+      comment: '울릉도 스페셜 뱃지입니다',
+    },
+    {
+      badge_id: '10',
+      name: '여수',
+      image: 'special6.jpg',
+      badge_type: '스페셜' as BadgeType,
+      region_id: 10,
+      comment: '여수 스페셜 뱃지입니다',
+    },
+  ]
+
+  const currentBadges = computed(() => (category.value === '지역' ? regionBadges : specialBadges))
+
+  const badgeCount = computed(() => currentBadges.value.length)
+
+  const changeCategory = (newCategory: BadgeCategoryType) => {
+    category.value = newCategory
+    showBadgeDetail.value = false
+    selectedBadge.value = null
+  }
+
+  const handleBadgeClick = (badge: Badge) => {
+    selectedBadge.value = badge
+    showBadgeDetail.value = true
+  }
+
+  const handleBackFromDetail = () => {
+    showBadgeDetail.value = false
+    selectedBadge.value = null
+  }
+
+  const badgeCollection: BadgeCollection = {
+    category: readonly(category),
+    selectedBadge: readonly(selectedBadge),
+    showBadgeDetail: readonly(showBadgeDetail),
+
+    regionBadges,
+    specialBadges,
+    currentBadges,
+    badgeCount,
+
+    changeCategory,
+    handleBadgeClick,
+    handleBackFromDetail,
+  }
+
+  provide(BADGE_COLLECTION_KEY, badgeCollection)
+  return badgeCollection
+}
+
+export function useBadgeCollection(): BadgeCollection {
+  const badgeCollection = inject(BADGE_COLLECTION_KEY)
+  if (!badgeCollection) {
+    throw new Error('useBadgeCollection은 provideBadgeCollection 후에 사용해야 합니다.')
+  }
+  return badgeCollection
+}

--- a/src/composables/badge/useBadgeCollection.ts
+++ b/src/composables/badge/useBadgeCollection.ts
@@ -1,12 +1,11 @@
 import { ref, computed, provide, inject, readonly } from 'vue'
 import type { InjectionKey } from 'vue'
-import type { BadgeType } from '@/types/badge'
-import type { BadgeCategoryType, Badge, BadgeCollection } from '@/types/badge'
+import type { BadgeType, Badge, BadgeCollection } from '@/types/badge'
 
 const BADGE_COLLECTION_KEY: InjectionKey<BadgeCollection> = Symbol('badge-collection')
 
 export function provideBadgeCollection(): BadgeCollection {
-  const category = ref<BadgeCategoryType>('지역')
+  const category = ref<BadgeType>('NORMAL')
   const selectedBadge = ref<Badge | null>(null)
   const showBadgeDetail = ref(false)
 
@@ -16,7 +15,7 @@ export function provideBadgeCollection(): BadgeCollection {
       badge_id: '1',
       name: '행운의 감자',
       image: 'img1.jpg',
-      badge_type: '지역' as BadgeType,
+      badge_type: 'NORMAL' as BadgeType,
       region_id: 1,
       comment: '행운의 감자 뱃지입니다',
     },
@@ -24,7 +23,7 @@ export function provideBadgeCollection(): BadgeCollection {
       badge_id: '2',
       name: '돌하르방의 청혼',
       image: 'img4.jpg',
-      badge_type: '지역' as BadgeType,
+      badge_type: 'NORMAL' as BadgeType,
       region_id: 2,
       comment: '돌하르방의 청혼 뱃지입니다',
     },
@@ -35,69 +34,69 @@ export function provideBadgeCollection(): BadgeCollection {
       badge_id: '3',
       name: '부산',
       image: 'special1.jpg',
-      badge_type: '스페셜' as BadgeType,
+      badge_type: 'SPECIAL' as BadgeType,
       region_id: 3,
-      comment: '부산 스페셜 뱃지입니다',
+      comment: '부산 SPECIAL 뱃지입니다',
     },
     {
       badge_id: '4',
       name: '양산',
       image: 'special6.jpg',
-      badge_type: '스페셜' as BadgeType,
+      badge_type: 'SPECIAL' as BadgeType,
       region_id: 4,
-      comment: '양산 스페셜 뱃지입니다',
+      comment: '양산 SPECIAL 뱃지입니다',
     },
     {
       badge_id: '5',
       name: '양양',
       image: 'special1.jpg',
-      badge_type: '스페셜' as BadgeType,
+      badge_type: 'SPECIAL' as BadgeType,
       region_id: 5,
-      comment: '양양 스페셜 뱃지입니다',
+      comment: '양양 SPECIAL 뱃지입니다',
     },
     {
       badge_id: '6',
       name: '독도',
       image: 'special6.jpg',
-      badge_type: '스페셜' as BadgeType,
+      badge_type: 'SPECIAL' as BadgeType,
       region_id: 6,
-      comment: '독도 스페셜 뱃지입니다',
+      comment: '독도 SPECIAL 뱃지입니다',
     },
     {
       badge_id: '7',
       name: '전주',
       image: 'special1.jpg',
-      badge_type: '스페셜' as BadgeType,
+      badge_type: 'SPECIAL' as BadgeType,
       region_id: 7,
-      comment: '전주 스페셜 뱃지입니다',
+      comment: '전주 SPECIAL 뱃지입니다',
     },
     {
       badge_id: '8',
       name: '인천',
       image: 'special6.jpg',
-      badge_type: '스페셜' as BadgeType,
+      badge_type: 'SPECIAL' as BadgeType,
       region_id: 8,
-      comment: '인천 스페셜 뱃지입니다',
+      comment: '인천 SPECIAL 뱃지입니다',
     },
     {
       badge_id: '9',
       name: '울릉도',
       image: 'special1.jpg',
-      badge_type: '스페셜' as BadgeType,
+      badge_type: 'SPECIAL' as BadgeType,
       region_id: 9,
-      comment: '울릉도 스페셜 뱃지입니다',
+      comment: '울릉도 SPECIAL 뱃지입니다',
     },
     {
       badge_id: '10',
       name: '여수',
       image: 'special6.jpg',
-      badge_type: '스페셜' as BadgeType,
+      badge_type: 'SPECIAL' as BadgeType,
       region_id: 10,
-      comment: '여수 스페셜 뱃지입니다',
+      comment: '여수 SPECIAL 뱃지입니다',
     },
   ]
 
-  const currentBadges = computed(() => (category.value === '지역' ? regionBadges : specialBadges))
+  const currentBadges = computed(() => (category.value === 'NORMAL' ? regionBadges : specialBadges))
 
   const badgeCount = computed(() => currentBadges.value.length)
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -21,6 +21,7 @@ import SignUpPage from '@/views/auth/SignUpPage.vue'
 import LocalCardCreateSelectLocalPage from '@/views/wallet/create/LocalCardCreateSelectLocalPage.vue'
 import LocalCardCreateDetailPage from '@/views/wallet/create/LocalCardCreateDetailPage.vue'
 import PaymentPin from '@/views/auth/PaymentPinPage.vue'
+import BadgePage from '@/views/badge/BadgePage.vue'
 
 const routes = [
   {
@@ -100,6 +101,10 @@ const routes = [
   {
     path: '/map',
     component: MapPage,
+  },
+  {
+    path: '/badge',
+    component: BadgePage,
   },
   {
     path: '/login',

--- a/src/types/badge/index.d.ts
+++ b/src/types/badge/index.d.ts
@@ -1,1 +1,29 @@
 export type BadgeCategoryType = '지역' | '스페셜'
+
+export type BadgeType = 'NORMAL' | 'SPECIAL'
+
+export type Badge = {
+  badge_id: string
+  name: string
+  image: string
+  badge_type: BadgeType
+  region_id: number
+  comment: string
+}
+
+export interface BadgeCollection {
+  category: Readonly<Ref<BadgeCategoryType>>
+  selectedBadge: Readonly<Ref<Badge | null>>
+  showBadgeDetail: Readonly<Ref<boolean>>
+
+  regionBadges: Badge[]
+  specialBadges: Badge[]
+  currentBadges: Readonly<ComputedRef<Badge[]>>
+  badgeCount: Readonly<ComputedRef<number>>
+
+  changeCategory: (newCategory: BadgeCategoryType) => void
+  handleBadgeClick: (badge: Badge) => void
+  handleBackFromDetail: () => void
+}
+
+export const BADGE_COLLECTION_KEY = Symbol('badge-collection') as InjectionKey<BadgeCollection>

--- a/src/types/badge/index.d.ts
+++ b/src/types/badge/index.d.ts
@@ -1,0 +1,1 @@
+export type BadgeCategoryType = '지역' | '스페셜'

--- a/src/types/badge/index.d.ts
+++ b/src/types/badge/index.d.ts
@@ -1,5 +1,3 @@
-export type BadgeCategoryType = '지역' | '스페셜'
-
 export type BadgeType = 'NORMAL' | 'SPECIAL'
 
 export type Badge = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -21,7 +21,7 @@ export interface ApiResponse<T = Record<string, object>> {
 export type BottomNaviType = 'wallet' | 'map' | 'qr' | 'badge' | 'my'
 
 // 공통 레이아웃에서 사용하는 헤더 타입
-export type HeaderType = 'basic' | 'main' | 'pay' | 'setting'
+export type HeaderType = 'basic' | 'main' | 'pay' | 'setting' | 'none'
 
 // 레이아웃 컴포넌트에서 사용하는 공통 타입
 export interface BaseLayoutProps {
@@ -45,6 +45,7 @@ export type LayoutProps =
   | ({ headerType: 'basic' | 'setting' } & HeaderWithTitle & BaseLayoutProps)
   | ({ headerType: 'main' } & BaseLayoutProps)
   | ({ headerType: 'pay' } & PayHeaderProps & BaseLayoutProps)
+  | ({ headerType: 'none' } & BaseLayoutProps)
 
 //가맹점 정보 타입
 export interface LocalStore {

--- a/src/views/badge/BadgePage.vue
+++ b/src/views/badge/BadgePage.vue
@@ -6,7 +6,7 @@ import Layout from '@/components/layout/Layout.vue'
 <template>
   <layout :header-type="'basic'" :header-title="'뱃지도감'" :is-bottom-nav="true">
     <template #content>
-      <div class="flex flex-col items-center justify-center px-[0.9rem] pt-[0.8rem] bg-Gray-0">
+      <div class="flex flex-col items-center justify-center px-[0.9rem] pt-[1.4rem] bg-Gray-0">
         <badge-page-info />
         <badge-collection-container />
       </div>

--- a/src/views/badge/BadgePage.vue
+++ b/src/views/badge/BadgePage.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import BadgePageInfo from '@/components/badge/BadgePageInfo.vue'
+import BadgeCollectionContainer from '@/components/badge/BadgeCollectionContainer.vue'
+import Layout from '@/components/layout/Layout.vue'
+</script>
+<template>
+  <layout :header-type="'basic'" :header-title="'뱃지도감'" :is-bottom-nav="true">
+    <template #content>
+      <div class="flex flex-col items-center justify-center px-[0.9rem] pt-[0.8rem] bg-Gray-0">
+        <badge-page-info />
+        <badge-collection-container />
+      </div>
+    </template>
+  </layout>
+</template>
+<style scoped></style>

--- a/src/views/badge/BadgePage.vue
+++ b/src/views/badge/BadgePage.vue
@@ -6,7 +6,7 @@ import Layout from '@/components/layout/Layout.vue'
 <template>
   <layout :header-type="'basic'" :header-title="'뱃지도감'" :is-bottom-nav="true">
     <template #content>
-      <div class="flex flex-col items-center justify-center px-[0.9rem] pt-[1.4rem] bg-Gray-0">
+      <div class="flex flex-col items-center justify-center px-[0.9rem] bg-Gray-0">
         <badge-page-info />
         <badge-collection-container />
       </div>


### PR DESCRIPTION
## 📌 Issues
- closed #73

## 🏁 Work Description
- badge UI 구현했습니다!
- 백엔드의 뱃지 테이블 요소를 참고해서 일단 타입을 아래와 같이 지정했습니다!

```ts
export type BadgeType = 'NORMAL' | 'SPECIAL'

export type Badge = {
  badge_id: string
  name: string
  image: string
  badge_type: BadgeType
  region_id: number
  comment: string
}
```
- useBadgeCollection.ts를 통해 BadgePage에 필요한 정보들을 간단하게 provide, inject 할 수 있게 구성했습니다!

```ts
const badgeCollection: BadgeCollection = {
    category: readonly(category),
    selectedBadge: readonly(selectedBadge),
    showBadgeDetail: readonly(showBadgeDetail),

    regionBadges,
    specialBadges,
    currentBadges,
    badgeCount,

    changeCategory,
    handleBadgeClick,
    handleBackFromDetail,
  }

  provide(BADGE_COLLECTION_KEY, badgeCollection)
  return badgeCollection

```

## 💬 PR Points
- 뱃지 단건 조회 페이지에서 뒤로가기를 넣지 않아도 버튼 탭에 있는 '지역', '스페셜'을 누르면 돌아갈 수 있어서 일단은 스크린샷처럼 작동하도록 UI를 구현했습니다! 혹시 플로우가 부자연스럽거나 불편하다면 수정하겠습니다-!

## 📷 Screenshot

https://github.com/user-attachments/assets/44ca5d2e-4484-4a95-82a2-c6f9d8c9673f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 뱃지 컬렉션(지역/스페셜) 페이지 및 상세 보기 UI가 추가되었습니다.
  * 뱃지 카테고리별 탭 전환, 뱃지 리스트, 뱃지 상세 정보 확인 기능이 제공됩니다.
  * 뱃지 페이지 안내 메시지가 추가되었습니다.
  * 새로운 뱃지 관련 라우트(`/badge`)가 생성되었습니다.

* **스타일**
  * 일부 레이아웃 및 배경 색상이 개선되었습니다.

* **타입**
  * 뱃지 및 레이아웃 관련 타입이 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->