### PR TITLE
[Feature/scrum 136] : pay api

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,12 +1,13 @@
 import type { ApiError } from '@/types/types'
 import axios, { type AxiosInstance } from 'axios'
+import type { AxiosResponse } from 'axios'
 
 const BASE_URL = import.meta.env.VITE_APP_BASE_URL
 
 // API Response 공통 타입 - error 등 구체적인 타입은 수정 가능성 있음
 export interface ApiResponse<T> {
-  data?: T
-  error?: ApiError
+  data: T
+  error: ApiError
   status: string
 }
 
@@ -19,22 +20,24 @@ export const instance: AxiosInstance = axios.create({
   },
 })
 
-export function get<T>(...args: Parameters<typeof instance.get>) {
-  return instance.get<T, T>(...args)
+export type ApiResult<T> = AxiosResponse<ApiResponse<T>>
+
+export function get<T>(...args: Parameters<typeof instance.get>): Promise<ApiResult<T>> {
+  return instance.get<ApiResponse<T>>(...args)
 }
 
-export function post<T>(...args: Parameters<typeof instance.post>) {
-  return instance.post<T>(...args)
+export function post<T>(...args: Parameters<typeof instance.post>): Promise<ApiResult<T>> {
+  return instance.post<ApiResponse<T>>(...args)
 }
 
-export function put<T>(...args: Parameters<typeof instance.put>) {
-  return instance.put<T>(...args)
+export function put<T>(...args: Parameters<typeof instance.put>): Promise<ApiResult<T>> {
+  return instance.put<ApiResponse<T>>(...args)
 }
 
-export function patch<T>(...args: Parameters<typeof instance.patch>) {
-  return instance.patch<T, T>(...args)
+export function patch<T>(...args: Parameters<typeof instance.patch>): Promise<ApiResult<T>> {
+  return instance.patch<ApiResponse<T>>(...args)
 }
 
-export function del<T>(...args: Parameters<typeof instance.delete>) {
-  return instance.delete<T>(...args)
+export function del<T>(...args: Parameters<typeof instance.delete>): Promise<ApiResult<T>> {
+  return instance.delete<ApiResponse<T>>(...args)
 }

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -11,17 +11,17 @@ import type {
 // 로그인
 export const login = async (payload: LoginRequest): Promise<LoginResponse> => {
   const { data } = await post<LoginResponse>('/api/auth/login', payload)
-  return data
+  return data.data
 }
 
 // 회원가입
 export const signUp = async (payload: SignUpRequest): Promise<SignUpResponse> => {
   const { data } = await post<SignUpResponse>('/api/auth/signup', payload)
-  return data
+  return data.data
 }
 
 // PIN 설정
 export const setPin = async (payload: SetPinRequest): Promise<SetPinResponse> => {
   const { data } = await post<SetPinResponse>('/api/auth/pin', payload)
-  return data
+  return data.data
 }

--- a/src/composables/badge/useBadgeCollection.ts
+++ b/src/composables/badge/useBadgeCollection.ts
@@ -100,7 +100,7 @@ export function provideBadgeCollection(): BadgeCollection {
 
   const badgeCount = computed(() => currentBadges.value.length)
 
-  const changeCategory = (newCategory: BadgeCategoryType) => {
+  const changeCategory = (newCategory: BadgeType) => {
     category.value = newCategory
     showBadgeDetail.value = false
     selectedBadge.value = null

--- a/src/composables/queries/local/useGetLocalCurrencies.ts
+++ b/src/composables/queries/local/useGetLocalCurrencies.ts
@@ -7,9 +7,7 @@ import type { localcurrencyResponseDtoType } from '@/types/local/localTypes'
 import type { AxiosResponse } from 'axios'
 import { computed, type Ref } from 'vue'
 
-export const getLocalCurrencies = async (
-  query: localcurrencyListRequestDtoType,
-): Promise<localcurrencyResponseDtoType[]> => {
+export const getLocalCurrencies = async (query: localcurrencyListRequestDtoType) => {
   const response: AxiosResponse<ApiResponse<localcurrencyResponseDtoType[]>> = await get(
     '/api/local-currencies',
     { params: query },

--- a/src/composables/queries/local/useGetLocals.ts
+++ b/src/composables/queries/local/useGetLocals.ts
@@ -1,12 +1,10 @@
 import { useQuery } from '@tanstack/vue-query'
-import type { ApiResponse } from '@/types/types'
 import { get } from '@/api/api'
 import { LOCAL_KEYS } from '@/constants/QueryKey'
 import type { localResponseDtoType } from '@/types/local/localTypes'
-import type { AxiosResponse } from 'axios'
 
 export const getLocals = async (): Promise<localResponseDtoType[]> => {
-  const response: AxiosResponse<ApiResponse<localResponseDtoType[]>> = await get('/api/regions', {
+  const response = await get<localResponseDtoType[]>('/api/regions', {
     params: {
       hasLocalCurrency: true,
     },


### PR DESCRIPTION
## 📌 Issues
- closed #81 

## 🏁 Work Description
### 공용함수 더 편하게 쓸 수 있도록 수정했습니다!

- BEFORE

```vue
export const getLocals = async (): Promise<localResponseDtoType[]> => {
  const response: AxiosResponse<ApiResponse<localResponseDtoType[]>> = await get('/api/regions', {
    params: { hasLocalCurrency: true },
  })
  return response.data.data
}
```

- AFTER

```vue
export const getLocals = async (): Promise<localResponseDtoType[]> => {
  const response = await get<localResponseDtoType[]>('/api/regions', {
    params: { hasLocalCurrency: true },
  })
  return response.data.data ?? []
}
```

### Type 잘못 지정해서 에러 나는 부분도 수정했습니다!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * API 응답 형식 및 반환 타입이 명확하게 지정되어 일부 데이터 처리 오류 가능성이 줄어듭니다.
  * 배지 카테고리 변경 시, 선택 매개변수 타입이 일관성 있게 수정되었습니다.
  * 지역 통화 및 지역 목록 조회 함수의 타입 선언이 간소화되어 코드 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->