### PR TITLE
[Feature/scrum 125] :  카드 순서 바꾸기 API 연동

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -16,7 +16,7 @@ export const instance: AxiosInstance = axios.create({
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
-    Authorization: `Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDAiLCJpYXQiOjE3NTQwMTE1NDMsImV4cCI6MzMyOTAwMTE1NDMsInVzZXJuYW1lIjoidGVzdGVyIiwicm9sZSI6IlJPTEVfQURNSU4ifQ.6016EI8NsaegS1Zl0y1FwbzoEBTBX5TY6hKKSgK1LtI`,
+    // Authorization: `Bearer ${import.meta.env.VITE_DEV_ACCESS_TOKEN}`,
   },
 })
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -16,7 +16,7 @@ export const instance: AxiosInstance = axios.create({
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
-    Authorization: `Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDAiLCJpYXQiOjE3NTQwMTE1NDMsImV4cCI6MzMyOTAwMTE1NDMsInVzZXJuYW1lIjoidGVzdGVyIiwicm9sZSI6IlJPTEVfQURNSU4ifQ.6016EI8NsaegS1Zl0y1FwbzoEBTBX5TY6hKKSgK1LtI`,
+    Authorization: `Bearer ${import.meta.env.VITE_DEV_ACCESS_TOKEN}`,
   },
 })
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -16,7 +16,7 @@ export const instance: AxiosInstance = axios.create({
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
-    //  Authorization: `${getAccessTokenLocalStorage()}`
+    Authorization: `Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDAiLCJpYXQiOjE3NTQwMTE1NDMsImV4cCI6MzMyOTAwMTE1NDMsInVzZXJuYW1lIjoidGVzdGVyIiwicm9sZSI6IlJPTEVfQURNSU4ifQ.6016EI8NsaegS1Zl0y1FwbzoEBTBX5TY6hKKSgK1LtI`,
   },
 })
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -16,7 +16,7 @@ export const instance: AxiosInstance = axios.create({
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
-    Authorization: `Bearer ${import.meta.env.VITE_DEV_ACCESS_TOKEN}`,
+    Authorization: `Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDAiLCJpYXQiOjE3NTQwMTE1NDMsImV4cCI6MzMyOTAwMTE1NDMsInVzZXJuYW1lIjoidGVzdGVyIiwicm9sZSI6IlJPTEVfQURNSU4ifQ.6016EI8NsaegS1Zl0y1FwbzoEBTBX5TY6hKKSgK1LtI`,
   },
 })
 

--- a/src/composables/queries/wallet/getWalletList.ts
+++ b/src/composables/queries/wallet/getWalletList.ts
@@ -12,8 +12,7 @@ export const getWalletList = async (
     params: { walletType },
   })
 
-  // 구조 파악 후 적절히 수정
-  const wallets = response.data?.data ?? [] // 또는 올바른 경로
+  const wallets = response.data?.data ?? []
 
   return wallets.filter((w: WalletResponseDtoType) => w.walletType === walletType)
 }

--- a/src/composables/queries/wallet/patchWalletOrder.ts
+++ b/src/composables/queries/wallet/patchWalletOrder.ts
@@ -1,36 +1,5 @@
 import { patch } from '@/api/api'
-
-interface WalletOrderItem {
-  displayOrder: number
-  walletId: string
-}
-
-// 백엔드 응답 타입
-interface ApiResponse<T> {
-  data: T
-  error?: {
-    code: string
-    errors: Array<{
-      field: string
-      reason: string
-    }>
-    message: string
-    method: string
-  }
-  status: string
-}
-
-// 업데이트된 지갑 데이터 타입 (응답에서 받는 형태)
-interface UpdatedWallet {
-  balance: number
-  createdAt: string
-  displayOrder: number
-  localCurrencyId: string
-  memberId: string
-  updatedAt: string
-  walletId: string
-  walletType: 'CASH' | 'LOCAL'
-}
+import type { WalletOrderItem, ApiResponse, UpdatedWallet } from '@/types/wallet/WalletOrder'
 
 export const updateWalletOrder = async (walletOrderList: WalletOrderItem[]) => {
   const response = await patch<ApiResponse<UpdatedWallet[]>>('/api/wallets/order', walletOrderList)

--- a/src/composables/queries/wallet/patchWalletOrder.ts
+++ b/src/composables/queries/wallet/patchWalletOrder.ts
@@ -1,10 +1,8 @@
 import { patch } from '@/api/api'
-import type { WalletOrderItem, ApiResponse, UpdatedWallet } from '@/types/wallet/WalletOrder'
+import type { WalletOrderItem, UpdatedWallet } from '@/types/wallet/WalletOrder'
 
 export const updateWalletOrder = async (walletOrderList: WalletOrderItem[]) => {
-  const response = await patch<ApiResponse<UpdatedWallet[]>>('/api/wallets/order', walletOrderList)
-
-  return response
+  return await patch<UpdatedWallet[]>('/api/wallets/order', walletOrderList)
 }
 
 export default updateWalletOrder

--- a/src/composables/queries/wallet/patchWalletOrder.ts
+++ b/src/composables/queries/wallet/patchWalletOrder.ts
@@ -1,0 +1,41 @@
+import { patch } from '@/api/api'
+
+interface WalletOrderItem {
+  displayOrder: number
+  walletId: string
+}
+
+// 백엔드 응답 타입
+interface ApiResponse<T> {
+  data: T
+  error?: {
+    code: string
+    errors: Array<{
+      field: string
+      reason: string
+    }>
+    message: string
+    method: string
+  }
+  status: string
+}
+
+// 업데이트된 지갑 데이터 타입 (응답에서 받는 형태)
+interface UpdatedWallet {
+  balance: number
+  createdAt: string
+  displayOrder: number
+  localCurrencyId: string
+  memberId: string
+  updatedAt: string
+  walletId: string
+  walletType: 'CASH' | 'LOCAL'
+}
+
+export const updateWalletOrder = async (walletOrderList: WalletOrderItem[]) => {
+  const response = await patch<ApiResponse<UpdatedWallet[]>>('/api/wallets/order', walletOrderList)
+
+  return response
+}
+
+export default updateWalletOrder

--- a/src/types/wallet/WalletOrder.ts
+++ b/src/types/wallet/WalletOrder.ts
@@ -4,23 +4,6 @@ export interface WalletOrderItem {
   walletId: string
 }
 
-// 백엔드 응답 공통 타입
-export interface ApiError {
-  code: string
-  errors: Array<{
-    field: string
-    reason: string
-  }>
-  message: string
-  method: string
-}
-
-export interface ApiResponse<T> {
-  data: T
-  error?: ApiError
-  status: string
-}
-
 // 지갑 응답 데이터 타입
 export interface UpdatedWallet {
   balance: number

--- a/src/types/wallet/WalletOrder.ts
+++ b/src/types/wallet/WalletOrder.ts
@@ -1,0 +1,34 @@
+// 지갑 순서 변경 요청용
+export interface WalletOrderItem {
+  displayOrder: number
+  walletId: string
+}
+
+// 백엔드 응답 공통 타입
+export interface ApiError {
+  code: string
+  errors: Array<{
+    field: string
+    reason: string
+  }>
+  message: string
+  method: string
+}
+
+export interface ApiResponse<T> {
+  data: T
+  error?: ApiError
+  status: string
+}
+
+// 지갑 응답 데이터 타입
+export interface UpdatedWallet {
+  balance: number
+  createdAt: string
+  displayOrder: number
+  localCurrencyId: string
+  memberId: string
+  updatedAt: string
+  walletId: string
+  walletType: 'CASH' | 'LOCAL'
+}

--- a/src/views/wallet/change/OrderChangePage.vue
+++ b/src/views/wallet/change/OrderChangePage.vue
@@ -22,6 +22,7 @@ interface WalletCard {
   balance: number
   displayOrder: number
   bgColorClass: string
+  walletType: 'CASH' | 'LOCAL'
 }
 
 // 색상 배열
@@ -78,9 +79,7 @@ const saveOrder = async () => {
     // 백엔드 로직에 따라 2부터 순서 반영
     displayOrder: index + 2,
   }))
-  walletOrderList.forEach((item) => {
-    const wallet = cards.value.find((w) => w.walletId === item.walletId)
-  })
+
   try {
     await updateWalletOrder(walletOrderList)
 

--- a/src/views/wallet/change/OrderChangePage.vue
+++ b/src/views/wallet/change/OrderChangePage.vue
@@ -1,51 +1,127 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watchEffect } from 'vue'
 import Layout from '@/components/layout/Layout.vue'
 import WalletItem from '@/components/common/wallet/WalletItem.vue'
 import DanjiButton from '@/components/common/button/DanjiButton.vue'
 import draggable from 'vuedraggable'
 
-interface WalletCard {
-  id: number
-  name: string
+import useGetWalletList from '@/composables/queries/wallet/getWalletList'
+import updateWalletOrder from '@/composables/queries/wallet/patchWalletOrder'
+
+// 원본 DTO 타입
+interface WalletResponseDtoType {
+  walletId: string
+  walletType: 'CASH' | 'LOCAL'
+  localCurrencyId: string
+  localCurrencyName: string
+  benefitType: string
+  percentage: number
   balance: number
+  displayOrder: number
+  backgroundImageUrl?: string | null
+  maximum?: number
+}
+
+// 화면에서 사용할 카드 타입
+interface WalletCard {
+  walletId: string
+  localCurrencyName: string
+  balance: number
+  displayOrder: number
   bgColorClass: string
 }
 
-const cards = ref<WalletCard[]>([
-  {
-    id: 1,
-    name: '통합지갑',
-    balance: 39400,
-    bgColorClass: 'bg-[#F6E3A2] text-black',
-  },
-  {
-    id: 2,
-    name: '울산페이',
-    balance: 39400,
-    bgColorClass: 'bg-[#77C3E4] text-white',
-  },
-  {
-    id: 3,
-    name: '강릉페이',
-    balance: 39400,
-    bgColorClass: 'bg-[#C89E59] text-white',
-  },
-  {
-    id: 4,
-    name: '부산페이',
-    balance: 39400,
-    bgColorClass: 'bg-[#F1F1F1] text-black',
-  },
-])
+// 순서 변경 API용 타입
+interface WalletOrderItem {
+  walletId: string
+  displayOrder: number
+}
 
-// 통합지갑 제외 나머지 카드만 드래그 가능
-const otherCards = ref(cards.value.slice(1))
+// 색상 배열
+const bgColors = [
+  'bg-[#0078D7] text-White-1',
+  'bg-[#77C3E4] text-White-1',
+  'bg-[#C89E59] text-White-1',
+  'bg-[#F1F1F1] text-Black-1',
+  'bg-[#FF8A65] text-White-1',
+]
 
-const saveOrder = () => {
-  const newOrder = [cards.value[0], ...otherCards.value]
-  console.log('저장 로직 구현')
-  //   추후에 연동 예정
+const localWallets = useGetWalletList('LOCAL')
+const cards = ref<WalletCard[]>([])
+const isDragging = ref(false)
+const hasUnsavedChanges = ref(false)
+
+// 원본 데이터를 화면용 카드로 변환하는 함수
+const convertToWalletCards = (wallets: WalletResponseDtoType[]): WalletCard[] => {
+  const sorted = [...wallets].sort((a, b) => a.displayOrder - b.displayOrder)
+
+  return sorted.map((wallet, index) => ({
+    walletId: wallet.walletId,
+    localCurrencyName: wallet.localCurrencyName,
+    balance: wallet.balance,
+    displayOrder: wallet.displayOrder,
+    bgColorClass: bgColors[index % bgColors.length],
+    walletType: wallet.walletType,
+  }))
+}
+
+// 데이터가 변경될 때마다 카드 목록 업데이트
+watchEffect(() => {
+  if (localWallets.value.length > 0 && !isDragging.value && !hasUnsavedChanges.value) {
+    cards.value = convertToWalletCards(localWallets.value)
+  }
+})
+
+// 드래그 시작
+const onDragStart = () => {
+  isDragging.value = true
+}
+
+// 드래그 끝
+const onDragEnd = () => {
+  isDragging.value = false
+  hasUnsavedChanges.value = true
+}
+
+// 순서 저장
+const saveOrder = async () => {
+  // 현재 카드 순서대로 displayOrder 부여
+  const walletOrderList: WalletOrderItem[] = cards.value.map((card, index) => ({
+    walletId: card.walletId,
+    displayOrder: index + 1,
+  }))
+  walletOrderList.forEach((item) => {
+    const wallet = cards.value.find((w) => w.walletId === item.walletId)
+  })
+  try {
+    await updateWalletOrder(walletOrderList)
+
+    // 성공 시: 저장된 순서로 화면 업데이트
+    cards.value = cards.value.map((card, index) => ({
+      ...card,
+      displayOrder: index,
+    }))
+
+    // 저장 후 상태 초기화
+    hasUnsavedChanges.value = false
+
+    alert('저장 완료!')
+
+    // 데이터 새로고침
+  } catch (error) {
+    // CORS 에러 등 네트워크 오류 처리
+    console.error('순서 저장 실패:', error)
+
+    console.log('전송한 데이터:', walletOrderList)
+
+    // 에러 발생 시에도 로컬에서는 순서 유지
+    // 백엔드 연결이 안 될 때 임시로 화면만 업데이트
+    cards.value = cards.value.map((card, index) => ({
+      ...card,
+      displayOrder: index + 1,
+    }))
+    hasUnsavedChanges.value = false
+  }
 }
 </script>
 
@@ -63,16 +139,18 @@ const saveOrder = () => {
           <div class="mb-[1rem] Body04 text-Black2">지갑 순서를 바꿔보세요</div>
 
           <draggable
-            v-model="otherCards"
-            item-key="id"
+            v-model="cards"
+            item-key="walletId"
             handle=".drag-handle"
             class="flex flex-col gap-[1rem] pb-[1.5rem] mt-[1rem]"
             animation="200"
             ghost-class="drag-ghost"
+            @start="onDragStart"
+            @end="onDragEnd"
           >
             <template #item="{ element }">
               <wallet-item
-                :name="element.name"
+                :name="element.localCurrencyName"
                 :balance="element.balance"
                 :bgColorClass="element.bgColorClass"
                 :showMenu="true"
@@ -82,7 +160,9 @@ const saveOrder = () => {
         </div>
 
         <div class="pt-[1rem]">
-          <danji-button variant="large" @click="saveOrder">저장하기</danji-button>
+          <danji-button variant="large" :disabled="!hasUnsavedChanges" @click="saveOrder">
+            저장하기
+          </danji-button>
         </div>
       </div>
     </template>

--- a/src/views/wallet/change/OrderChangePage.vue
+++ b/src/views/wallet/change/OrderChangePage.vue
@@ -88,7 +88,7 @@ const saveOrder = async () => {
   // 현재 카드 순서대로 displayOrder 부여
   const walletOrderList: WalletOrderItem[] = cards.value.map((card, index) => ({
     walletId: card.walletId,
-    displayOrder: index + 1,
+    displayOrder: index + 2,
   }))
   walletOrderList.forEach((item) => {
     const wallet = cards.value.find((w) => w.walletId === item.walletId)

--- a/src/views/wallet/change/OrderChangePage.vue
+++ b/src/views/wallet/change/OrderChangePage.vue
@@ -109,10 +109,10 @@ const saveOrder = async () => {
 
 <template>
   <Layout
-    :header-type="'setting'"
+    :header-type="'basic'"
     :header-title="'설정'"
     :show-left-icon="true"
-    :show-right-icon="true"
+    :show-right-icon="false"
     :is-bottom-nav="false"
   >
     <template #content>

--- a/src/views/wallet/change/OrderChangePage.vue
+++ b/src/views/wallet/change/OrderChangePage.vue
@@ -100,7 +100,6 @@ const saveOrder = async () => {
     })
   } catch (error) {
     console.error('순서 저장 실패:', error)
-    console.log('전송한 데이터:', walletOrderList)
     alert('저장에 실패했어요.')
     hasUnsavedChanges.value = false
   }


### PR DESCRIPTION
## 📌 Issues
- closed #71 

## 🏁 Work Description
- 카드 순서 바꾸기 API 연동

## 💬 PR Points
- 순서 바꾸기 버튼 클릭 시, 지갑 순서 변경 페이지(/order)로 이동합니다.
- 드래그 앤 드롭으로 지갑 순서를 변경할 수 있으며, 순서가 변경되지 않은 경우 저장 버튼은 비활성화됩니다.
- 저장 시, 서버에 순서를 업데이트한 뒤 /order 페이지로 이동하며 자동 새로고침됩니다.
- 현재 배경 색상은 5가지를 순서대로 순환 지정하고 있으며, 추후 색상 수를 유동적으로 확장할 수 있도록 개선할 예정입니다.

## 📷 Screenshot
<img width="457" height="800" alt="image" src="https://github.com/user-attachments/assets/7cb02bae-3fc0-45bb-917c-9b24d64cfd5e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 지갑 순서 변경 페이지에서 지갑 목록을 동적으로 불러오고, 드래그 앤 드롭으로 순서를 변경한 후 저장할 수 있습니다.
  * 순서 변경 내역을 저장하면 백엔드와 동기화되며, 성공 시 사용자에게 알림이 표시됩니다.

* **UI/UX 개선**
  * 저장되지 않은 변경 사항이 있을 때만 저장 버튼이 활성화됩니다.
  * 지갑 카드에 색상 팔레트가 적용되어 시각적으로 구분이 용이합니다.
  * 헤더 타입과 아이콘 노출 방식이 변경되었습니다.

* **버그 수정**
  * 지갑 카드 정보가 실시간으로 반영되며, 드래그 중에는 불필요한 갱신이 발생하지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->