### PR TITLE
[Feature/scrum 147] : 충전/환전 충전 금액 및 인센티브 값 연동

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -16,7 +16,7 @@ export const instance: AxiosInstance = axios.create({
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
-    Authorization: `Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDAiLCJpYXQiOjE3NTQwMTE1NDMsImV4cCI6MzMyOTAwMTE1NDMsInVzZXJuYW1lIjoidGVzdGVyIiwicm9sZSI6IlJPTEVfQURNSU4ifQ.6016EI8NsaegS1Zl0y1FwbzoEBTBX5TY6hKKSgK1LtI`,
+    Authorization: `Bearer ${import.meta.env.VITE_DEV_ACCESS_TOKEN}`,
   },
 })
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -16,7 +16,7 @@ export const instance: AxiosInstance = axios.create({
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
-    Authorization: `Bearer ${import.meta.env.VITE_DEV_ACCESS_TOKEN}`,
+    Authorization: `Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDAiLCJpYXQiOjE3NTQwMTE1NDMsImV4cCI6MzMyOTAwMTE1NDMsInVzZXJuYW1lIjoidGVzdGVyIiwicm9sZSI6IlJPTEVfQURNSU4ifQ.6016EI8NsaegS1Zl0y1FwbzoEBTBX5TY6hKKSgK1LtI`,
   },
 })
 

--- a/src/components/wallet/HasCardSection.vue
+++ b/src/components/wallet/HasCardSection.vue
@@ -51,9 +51,11 @@ onMounted(() => {
   <div class="flex flex-col gap-4 max-w-full overflow-hidden">
     <!-- 순서 바꾸기 버튼 -->
     <div class="flex items-center justify-between">
-      <div class="Body04 text-Black-2" :class="{ 'opacity-0': currentIndex >= sortedCards.length }">
+      <div class="Body04 text-Black-2">
         나의 카드
-        <span class="text-Gray-7"> {{ currentIndex + 1 }} / {{ sortedCards.length }} 개 </span>
+        <span class="text-Gray-7" :class="{ 'opacity-0': currentIndex >= sortedCards.length }">
+          {{ currentIndex + 1 }} / {{ sortedCards.length }} 개
+        </span>
       </div>
 
       <button

--- a/src/components/wallet/exchange/ExchageCard.vue
+++ b/src/components/wallet/exchange/ExchageCard.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { format } from 'date-fns'
 import { HandCoins } from 'lucide-vue-next'
 import type { BenefitType } from '@/types/local/localTypes'
 import { benefitTypeTextMap } from '@/utils/benefit'
 import type { WalletResponseDtoType } from '@/types/wallet/WalletResponseDtoType'
+
+// 충전/인센티브 금액 알기위해 날짜 받기
+const currentMonthLabel = format(new Date(), 'M월')
 
 const props = defineProps<{
   balance: number
@@ -59,9 +63,9 @@ const selectedCardBenefit = computed(() => {
 
     <!-- 내가 충전한 금액 / 인센티브 -->
     <div class="Body03 text-Gray-6">
-      내가 충전한 금액:
+      {{ currentMonthLabel }} 충전한 금액:
       <span class="text-Yellow-1">{{ props.chargedAmount.toLocaleString() }}원</span><br />
-      내가 받은 인센티브({{ props.percentage }}%):
+      {{ currentMonthLabel }} 받은 인센티브({{ props.percentage }}%):
       <span class="text-Yellow-1">{{ props.incentiveAmount.toLocaleString() }}원</span>
     </div>
 

--- a/src/components/wallet/exchange/ExchangeCash.vue
+++ b/src/components/wallet/exchange/ExchangeCash.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { format } from 'date-fns'
 import { calculateExchangeRegionToCash } from '@/utils/exchange'
 import { HandCoins } from 'lucide-vue-next'
+
+const currentMonthLabel = format(new Date(), 'M월')
 
 const props = defineProps<{
   balance: number
@@ -41,9 +44,9 @@ const excludedIncentive = computed(() => {
 
     <!-- 내가 충전한 금액 / 인센티브 -->
     <div class="Body03 text-Gray-6">
-      내가 충전한 금액:
+      {{ currentMonthLabel }} 충전한 금액:
       <span class="text-Yellow-1">{{ props.chargedAmount.toLocaleString() }}원</span><br />
-      내가 받은 인센티브:
+      {{ currentMonthLabel }} 받은 인센티브({{ props.percentage }}%):
       <span class="text-Yellow-1">{{ props.incentiveAmount.toLocaleString() }}원</span>
     </div>
 

--- a/src/views/wallet/charge/CardChargePage.vue
+++ b/src/views/wallet/charge/CardChargePage.vue
@@ -172,9 +172,14 @@ const handleCharge = async () => {
 
             <!-- 혜택 계산 -->
             <div class="space-y-[0.4rem] mt-[1.2rem] Body03">
-              <p>
-                예상 수수료(1%):
-                <span class="text-Yellow-0">{{ fee.toLocaleString() }}원</span>
+              <p
+                class="flex items-center gap-2 Body03 text-Yellow-1 transition-all duration-300"
+                :class="{ 'border-t border-Gray-3 pt-[0.8rem] mt-[0.4rem]': amount }"
+              >
+                <span :class="{ 'line-through text-Yellow-0': amount, 'text-Yellow-0': !amount }">
+                  예상 수수료(1%): {{ fee.toLocaleString() }}원
+                </span>
+                <span v-if="amount" class="text-Red-0">수수료 면제 대상입니다!</span>
               </p>
               <p v-if="benefitTypeTextMap[localWalletInfo.benefitType] === '인센티브'">
                 {{ localWalletInfo.localCurrencyName }}


### PR DESCRIPTION
## 📌 Issues
- closed #95 

## 🏁 Work Description
- 충전/환전하기 페이지에서 충전한 금액 및 받은 인센티브 값 연동

## 💬 PR Points
✅ 작업 내역
- 충전한 금액 및 인센티브 : 거래내역 API와 연동 완료
- 수수료 안내 문구 추가 :충전하기 페이지에서 금액 입력 시 “수수료 면제 대상입니다” 문구 표시
-
❓논의 사항 : 충전 금액 부족 시 안내 문구 개선 제안
- 현재는 *“통합지갑 < 충전할 금액”*일 때 (-)원으로 표기되고 있음
→ 사용자에게 혼란을 줄 수 있으므로, "충전 가능한 금액이 부족합니다" 와 같은 빨간 경고 문구로 변경하는 것이 좋을지 논의 필요

## 📷 Screenshot
<img width="457" height="795" alt="image" src="https://github.com/user-attachments/assets/9cd9e6f7-3563-4d2d-be3f-efa6a597e0e9" />
<img width="455" height="797" alt="image" src="https://github.com/user-attachments/assets/1e4b75ef-b5d9-4f21-a1d1-65f95da365a4" />

