### PR TITLE
[Feature/scrum 172] : pinia 연동(결제하기, 홈) 및 자잘한 QA

### DIFF
--- a/src/components/badge/BadgeDetail.vue
+++ b/src/components/badge/BadgeDetail.vue
@@ -15,7 +15,7 @@ const { selectedBadge } = useBadgeCollection()
       <img
         :src="selectedBadge?.image"
         :alt="`${selectedBadge?.name} 뱃지`"
-        class="w-[15.4rem] h-[15.4rem] bg-Gray-1"
+        class="w-[15.4rem] h-[15.4rem]"
       />
     </div>
     <div

--- a/src/components/badge/LocalBadgeCollection.vue
+++ b/src/components/badge/LocalBadgeCollection.vue
@@ -27,7 +27,7 @@ const chunkedBadges = computed(() => {
         :key="badge.badge_id"
         :src="badge.image"
         :alt="`${badge.name} 뱃지 ${badgeIndex + 1}`"
-        class="w-[6rem] h-[6rem] bg-Gray-1 cursor-pointer"
+        class="w-[6rem] h-[6rem] cursor-pointer"
         @click="handleBadgeClick(badge)"
       />
     </div>

--- a/src/components/badge/SpecialBadgeCollection.vue
+++ b/src/components/badge/SpecialBadgeCollection.vue
@@ -16,7 +16,7 @@ const { currentBadges, handleBadgeClick } = useBadgeCollection()
         :key="badge.badge_id"
         :src="badge.image"
         :alt="`${badge.name} 뱃지 ${index + 1}`"
-        class="w-[7rem] h-[7rem] bg-Gray-0"
+        class="w-[7rem] h-[7rem]"
       />
       <span class="Body01">{{ badge.name }}</span>
     </div>

--- a/src/components/badge/SpecialBadgeCollection.vue
+++ b/src/components/badge/SpecialBadgeCollection.vue
@@ -15,8 +15,10 @@ const { currentBadges, handleBadgeClick } = useBadgeCollection()
       <img
         :key="badge.badge_id"
         :src="badge.image"
-        :alt="`${badge.name} 뱃지 ${index + 1}`"
-        class="w-[7rem] h-[7rem]"
+        :alt="`${badge.name} 뱃지`"
+        class="w-[7rem] h-[7rem] object-contain"
+        loading="lazy"
+        decoding="async"
       />
       <span class="Body01">{{ badge.name }}</span>
     </div>

--- a/src/composables/pay/useLocation.ts
+++ b/src/composables/pay/useLocation.ts
@@ -29,10 +29,28 @@ export const useLocation = () => {
 
       // 현재 위치 가져오기
       const position = await new Promise<GeolocationPosition>((resolve, reject) => {
-        navigator.geolocation.getCurrentPosition(resolve, reject, {
-          enableHighAccuracy: true,
-          timeout: 10000,
-        })
+        navigator.geolocation.getCurrentPosition(
+          resolve,
+          (error) => {
+            if (error.code === error.PERMISSION_DENIED) {
+              reject(
+                new Error(
+                  '위치 권한이 거부되었습니다. 브라우저 설정에서 위치 권한을 허용해주세요.',
+                ),
+              )
+            } else if (error.code === error.POSITION_UNAVAILABLE) {
+              reject(new Error('위치 정보를 사용할 수 없습니다.'))
+            } else if (error.code === error.TIMEOUT) {
+              reject(new Error('위치 정보 요청 시간이 초과되었습니다.'))
+            } else {
+              reject(new Error('위치 정보를 가져올 수 없습니다.'))
+            }
+          },
+          {
+            enableHighAccuracy: true,
+            timeout: 10000,
+          },
+        )
       })
 
       const baseUrl = 'https://dapi.kakao.com/v2/local/geo/coord2address.json'

--- a/src/composables/pay/useLocation.ts
+++ b/src/composables/pay/useLocation.ts
@@ -1,0 +1,110 @@
+import { readonly, ref } from 'vue'
+import { useMemberStore } from '@/stores/useMemberStore'
+
+interface KakaoAddressResponse {
+  documents: Array<{
+    address: {
+      region_1depth_name: string // 시/도
+      region_2depth_name: string // 시/군/구
+      region_3depth_name: string // 읍/면/동
+    }
+    road_address?: {
+      region_1depth_name: string
+      region_2depth_name: string
+      region_3depth_name: string
+    }
+  }>
+}
+
+export const useLocation = () => {
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+
+  const fetchCurrentProvince = async () => {
+    const memberStore = useMemberStore()
+
+    try {
+      isLoading.value = true
+      error.value = null
+
+      // 현재 위치 가져오기
+      const position = await new Promise<GeolocationPosition>((resolve, reject) => {
+        navigator.geolocation.getCurrentPosition(resolve, reject, {
+          enableHighAccuracy: true,
+          timeout: 10000,
+        })
+      })
+
+      const baseUrl = 'https://dapi.kakao.com/v2/local/geo/coord2address.json'
+      const params = new URLSearchParams({
+        x: position.coords.longitude.toString(),
+        y: position.coords.latitude.toString(),
+        input_coord: 'WGS84',
+      })
+
+      const response = await fetch(`${baseUrl}?${params}`, {
+        method: 'GET',
+        headers: {
+          Authorization: `KakaoAK ${import.meta.env.VITE_KAKAO_REST_API_KEY}`,
+        },
+      })
+
+      if (!response.ok) {
+        throw new Error(`API 요청 실패: ${response.status}`)
+      }
+
+      const data: KakaoAddressResponse = await response.json()
+
+      if (data.documents.length === 0) {
+        throw new Error('주소를 찾을 수 없습니다.')
+      }
+
+      // 지역명 추출
+      const address = data.documents[0].address
+      const { region_1depth_name: r1, region_2depth_name: r2 } = address
+
+      // 서버 DB와 일치하는 지명 매핑
+      const regionFullNameMap: Record<string, string> = {
+        서울: '서울특별시',
+        부산: '부산광역시',
+        대구: '대구광역시',
+        인천: '인천광역시',
+        광주: '광주광역시',
+        대전: '대전광역시',
+        울산: '울산광역시',
+        세종: '세종특별자치시',
+        경기: '경기도',
+        강원: '강원도',
+        충북: '충청북도',
+        충남: '충청남도',
+        전북: '전라북도',
+        전남: '전라남도',
+        경북: '경상북도',
+        경남: '경상남도',
+        제주: '제주특별자치도',
+      }
+
+      const fullRegionName = regionFullNameMap[r1] || r1
+
+      const province = fullRegionName
+
+      console.log('현재 위치:', { r1, r2, fullRegionName, province })
+
+      memberStore.setCurrentLocation(province)
+      return province
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : '위치 정보를 가져올 수 없습니다.'
+      error.value = errorMessage
+      console.error('위치 정보 조회 오류:', err)
+      throw new Error(errorMessage)
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  return {
+    isLoading: readonly(isLoading),
+    error: readonly(error),
+    fetchCurrentProvince,
+  }
+}

--- a/src/composables/queries/wallet/useGetWallet.ts
+++ b/src/composables/queries/wallet/useGetWallet.ts
@@ -29,6 +29,9 @@ const useGetWallet = (walletId: string) => {
         displayOrder: 0,
         backgroundImageUrl: '',
         maximum: 0,
+        regionId: 0,
+        province: '',
+        city: '',
       },
   )
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
-import piniaPluginPersistedstate from 'pinia-plugin-persistedstate' // ⭐ 1. 추가
+import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 import { useKakao } from 'vue3-kakao-maps/@utils'
 import { VueQueryPlugin } from '@tanstack/vue-query'
 import { queryClient } from '@/api/queryClient'

--- a/src/stores/useMemberStore.ts
+++ b/src/stores/useMemberStore.ts
@@ -6,6 +6,7 @@ export const useMemberStore = defineStore('member', {
     username: '',
     password: '',
     paymentPin: '',
+    currentLocation: '',
   }),
   actions: {
     setInfo(payload: { name: string; username: string; password: string }) {
@@ -16,11 +17,16 @@ export const useMemberStore = defineStore('member', {
     setPaymentPin(pin: string) {
       this.paymentPin = pin
     },
+    setCurrentLocation(location: string) {
+      this.currentLocation = location
+    },
+
     reset() {
       this.name = ''
       this.username = ''
       this.password = ''
       this.paymentPin = ''
+      this.currentLocation = ''
     },
   },
 })

--- a/src/stores/useMemberStore.ts
+++ b/src/stores/useMemberStore.ts
@@ -29,4 +29,5 @@ export const useMemberStore = defineStore('member', {
       this.currentLocation = ''
     },
   },
+  persist: true,
 })

--- a/src/types/wallet/WalletResponseDtoType.ts
+++ b/src/types/wallet/WalletResponseDtoType.ts
@@ -14,6 +14,6 @@ export interface WalletResponseDtoType {
   backgroundImageUrl?: string | null
   maximum?: number
   regionId?: number
-  province: string
-  city: string
+  province?: string
+  city?: string
 }

--- a/src/types/wallet/WalletResponseDtoType.ts
+++ b/src/types/wallet/WalletResponseDtoType.ts
@@ -13,4 +13,7 @@ export interface WalletResponseDtoType {
   displayOrder: number
   backgroundImageUrl?: string | null
   maximum?: number
+  regionId?: number
+  province: string
+  city: string
 }

--- a/src/views/pay/PayPage.vue
+++ b/src/views/pay/PayPage.vue
@@ -32,7 +32,10 @@ console.log('현재 위치:', currentLocation.value)
 
 // 현재 지역의 지역화폐 찾기
 const currentLocalWallet = computed(() => {
-  const location = currentLocation.value
+  // const location = currentLocation.value
+  const location = '광주광역시' // 시연을 위해 고정값 임시 부여
+  console.log('현재 위치:', location)
+
   if (!location) return null
 
   return (
@@ -40,9 +43,10 @@ const currentLocalWallet = computed(() => {
       return (
         // 임시로 설정(추후 백엔드 수정 후 수정 예정)
         wallet.walletId === location ||
-        wallet.localCurrencyName?.includes(
+        wallet.province?.includes(
           location.replace(/특별시|광역시|특별자치시|특별자치도|도$/g, ''),
-        )
+        ) ||
+        wallet.city?.includes(location.replace(/특별시|광역시|특별자치시|특별자치도|도$/g, ''))
       )
     }) || null
   )
@@ -72,15 +76,15 @@ const paymentData = computed((): payRequestDtoType => {
 // 컴포넌트 마운트 시 위치 정보 및 지갑 정보 확인
 onMounted(() => {
   if (!currentLocation.value) {
-    console.warn('⚠️ 위치 정보가 없습니다.')
+    console.warn('위치 정보가 없습니다.')
   }
 
   if (!currentLocalWallet.value) {
-    console.warn('⚠️ 현재 지역의 지역화폐 지갑이 없습니다.')
+    console.warn('현재 지역의 지역화폐 지갑이 없습니다.')
   }
 
   // 지역화폐 여부에 따라 초기 결제 방식 자동 선택
-  if (currentLocalWallet.value && localBalance.value > 0) {
+  if (currentLocalWallet.value && localBalance.value >= 0) {
     selectedPayment.value = 'local'
   } else {
     selectedPayment.value = 'cash'
@@ -226,14 +230,18 @@ const handleInfoConfirm = async () => {
             <div v-if="selectedPayment === 'local'">
               <div class="relative w-[21rem] aspect-[1586/1000] rounded-[1.6rem] bg-Gray-10">
                 <img
-                  :src="`http://danji.cloud/static/images/localCurrency/gunsan.jpg`"
+                  :src="`http://danji.cloud${currentLocalWallet?.backgroundImageUrl}`"
                   alt="지역화폐-카드-이미지"
                 />
                 <div
                   class="absolute flex flex-col bottom-[1.4rem] left-[2.1rem] px-[0.7rem] py-[0.2rem] bg-White-1/50"
                 >
-                  <span class="text-Black-1 Head03">부산페이</span>
-                  <span class="text-Black-2 Body01">부산 지역화폐</span>
+                  <span class="text-Black-1 Head03">{{
+                    currentLocalWallet?.localCurrencyName
+                  }}</span>
+                  <span class="text-Black-2 Body01"
+                    >{{ currentLocalWallet?.province }} 지역화폐</span
+                  >
                 </div>
               </div>
             </div>

--- a/src/views/pay/PayPage.vue
+++ b/src/views/pay/PayPage.vue
@@ -40,14 +40,9 @@ const currentLocalWallet = computed(() => {
 
   return (
     walletStore.localWallets.find((wallet) => {
-      return (
-        // 임시로 설정(추후 백엔드 수정 후 수정 예정)
-        wallet.walletId === location ||
-        wallet.province?.includes(
-          location.replace(/특별시|광역시|특별자치시|특별자치도|도$/g, ''),
-        ) ||
-        wallet.city?.includes(location.replace(/특별시|광역시|특별자치시|특별자치도|도$/g, ''))
-      )
+      const parsedLocation = location.replace(/특별시|광역시|특별자치시|특별자치도|도$/g, '')
+
+      return wallet.province?.includes(parsedLocation) || wallet.city?.includes(parsedLocation)
     }) || null
   )
 })
@@ -228,10 +223,14 @@ const handleInfoConfirm = async () => {
 
             <!-- 카드 div(체크됐을 때만 표시) -->
             <div v-if="selectedPayment === 'local'">
-              <div class="relative w-[21rem] aspect-[1586/1000] rounded-[1.6rem] bg-Gray-10">
+              <div class="relative w-[21rem] aspect-[1586/1000] rounded-[0.8rem] bg-Gray-10">
                 <img
-                  class="object-cover w-full aspect-[1586/1000] rounded-[1.6rem]"
-                  :src="`http://danji.cloud${currentLocalWallet?.backgroundImageUrl}`"
+                  class="object-cover w-full aspect-[1586/1000] rounded-[0.8rem]"
+                  :src="
+                    currentLocalWallet?.backgroundImageUrl
+                      ? `http://danji.cloud${currentLocalWallet.backgroundImageUrl}`
+                      : ''
+                  "
                   alt="지역화폐-카드-이미지"
                 />
                 <div

--- a/src/views/pay/PayPage.vue
+++ b/src/views/pay/PayPage.vue
@@ -30,12 +30,6 @@ const showInfoModal = ref(false)
 const currentLocation = computed(() => memberStore.currentLocation)
 console.log('현재 위치:', currentLocation.value)
 
-const localBalance = computed(() => currentLocalWallet.value?.balance || 0)
-const cashBalance = computed(() => walletStore.cashWallet?.balance || 0)
-
-console.log('현금계좌 잔액', cashBalance.value)
-console.log('지역화폐 잔액', localBalance.value)
-
 // 현재 지역의 지역화폐 찾기
 const currentLocalWallet = computed(() => {
   const location = currentLocation.value
@@ -53,6 +47,12 @@ const currentLocalWallet = computed(() => {
     }) || null
   )
 })
+
+const localBalance = computed(() => currentLocalWallet.value?.balance || 0)
+const cashBalance = computed(() => walletStore.cashWallet?.balance || 0)
+
+console.log('현금계좌 잔액', cashBalance.value)
+console.log('지역화폐 잔액', localBalance.value)
 
 const paymentAmount = ref(30000) // 전체 결제요금 임시 설정
 const localPaymentAmount = ref(paymentAmount.value) // 지역화폐로 결제할 금액
@@ -91,7 +91,7 @@ onMounted(() => {
 const selectPayment = (type: PaymentType) => {
   // 지역화폐 선택 시 해당 지역의 지갑이 있는지 확인
   if (type === 'local' && !currentLocalWallet.value) {
-    alert('해당 지역의 지역화폐 지갑이 없습니다.')
+    alert('현재 지역의 지역화폐 카드가 없습니다.')
     return
   }
   selectedPayment.value = type

--- a/src/views/pay/PayPage.vue
+++ b/src/views/pay/PayPage.vue
@@ -33,7 +33,7 @@ console.log('현재 위치:', currentLocation.value)
 // 현재 지역의 지역화폐 찾기
 const currentLocalWallet = computed(() => {
   // const location = currentLocation.value
-  const location = '광주광역시' // 시연을 위해 고정값 임시 부여
+  const location = '제주특별자치도' // 시연을 위해 고정값 임시 부여
   console.log('현재 위치:', location)
 
   if (!location) return null
@@ -230,6 +230,7 @@ const handleInfoConfirm = async () => {
             <div v-if="selectedPayment === 'local'">
               <div class="relative w-[21rem] aspect-[1586/1000] rounded-[1.6rem] bg-Gray-10">
                 <img
+                  class="object-cover w-full aspect-[1586/1000] rounded-[1.6rem]"
                   :src="`http://danji.cloud${currentLocalWallet?.backgroundImageUrl}`"
                   alt="지역화폐-카드-이미지"
                 />

--- a/src/views/pay/PayPinPage.vue
+++ b/src/views/pay/PayPinPage.vue
@@ -6,6 +6,8 @@ import Layout from '@/components/layout/Layout.vue'
 import { useMemberStore } from '@/stores/useMemberStore'
 import usePostPayment from '@/composables/queries/payment/usePostPayment'
 import type { payRequestDtoType } from '@/types/pay/payTypes'
+import { useUiStore } from '@/stores/useUiStore'
+import { AxiosError } from 'axios'
 
 const store = useMemberStore()
 const router = useRouter()
@@ -62,6 +64,24 @@ async function confirmPin() {
       },
     })
   } catch (error) {
+    // 💡 에러 코드별 처리
+    if (
+      error instanceof AxiosError &&
+      error?.response?.data?.error?.message?.includes('결제 비밀번호가 일치하지 않습니다')
+    ) {
+      // console.log('결제 비밀번호가 일치하지 않습니다!!!')
+      useUiStore().setNextToast({
+        type: 'error',
+        msg: '결제 비밀번호가 일치하지 않습니다.',
+        opts: { position: 'bottom-center', autoClose: 1000 },
+      })
+
+      resetPin()
+
+      await router.push('/pay')
+      return
+    }
+
     router.push({
       path: '/pay-complete',
       state: {

--- a/src/views/pay/PayPinPage.vue
+++ b/src/views/pay/PayPinPage.vue
@@ -69,7 +69,6 @@ async function confirmPin() {
       error instanceof AxiosError &&
       error?.response?.data?.error?.message?.includes('결제 비밀번호가 일치하지 않습니다')
     ) {
-      // console.log('결제 비밀번호가 일치하지 않습니다!!!')
       useUiStore().setNextToast({
         type: 'error',
         msg: '결제 비밀번호가 일치하지 않습니다.',

--- a/src/views/wallet/home/HomePage.vue
+++ b/src/views/wallet/home/HomePage.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useRouter } from 'vue-router'
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 
 import Layout from '@/components/layout/Layout.vue'
 import DanjiButton from '@/components/common/button/DanjiButton.vue'
@@ -10,9 +10,25 @@ import NoCardSection from '@/components/wallet/NoCardSection.vue'
 
 import useHomeCardList from '@/composables/home/useHomeCardList'
 import { useWalletStore } from '@/stores/useWalletStore'
+import { useMemberStore } from '@/stores/useMemberStore'
+import { useLocation } from '@/composables/pay/useLocation'
 
 const router = useRouter()
 const walletStore = useWalletStore()
+const memberStore = useMemberStore()
+
+// 위치 정보 가져오기
+const { isLoading: isLocationLoading, error: locationError, fetchCurrentProvince } = useLocation()
+
+// 페이지 진입 시 현재 위치 가져오기
+const initializeLocation = async () => {
+  try {
+    const province = await fetchCurrentProvince()
+    console.log('현재 위치 저장 완료:', province)
+  } catch (error) {
+    console.error('위치 정보 가져오기 실패:', error)
+  }
+}
 
 const { sortedLocalWallets, localWalletCount } = useHomeCardList()
 
@@ -38,6 +54,11 @@ const goExchange = () => {
   const selectedCard = sortedLocalWallets.value[currentIndex.value]
   if (selectedCard) router.push(`/card/exchange/${selectedCard.walletId}`)
 }
+
+// 컴포넌트 마운트 시 위치 정보 초기화
+onMounted(() => {
+  initializeLocation()
+})
 </script>
 
 <template>


### PR DESCRIPTION
## 📌 Issues
- closed #133 

## 🏁 Work Description
- pinia에 저장해놓은 지갑 정보를 참조해서 결제하기 뷰와 연동
- 홈화면에 진입하면 현재 위치를 저장하고 카카오 API를 활용해 위도 경도를 바탕으로 현재 위치의 주소를 한글로 받습니다
- 받은 한글 주소를 가지고 현재 위치에서 사용 가능한 지역화폐를 자동으로 가져와 보여줍니다
    - 로직은 구현했지만 시연할 때 실제로 다른 지역을 갈 수 없으니 임시로 고정값을 할당해주었습니다
 - 결제 비밀번호가 틀려서 결제 실패가 발생할 때는 라우팅을 다시 결제하기 페이지로 돌아가도록 처리했습니다
## 💬 PR Points
- 공용 토스트 ui 적용했는데 토스트 메시지가 2개씩 뜨는 문제가 있습니다ㅠㅠ 추후 QA에서 다같이 고치겠습니다!
## 📷 Screenshot

https://github.com/user-attachments/assets/810ce728-97e2-4dbf-be02-25fd12b18913



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 현재 위치 기반 시·도 자동 감지(useLocation) 및 멤버 스토어에 영구 저장(persist)되어 화면에 반영.
  - 지갑 홈에서 현금 잔액·지역 지갑 정보 실시간 표시 및 상황에 맞춘 초기 결제 수단 자동 선택.
  - 결제 화면에 지역 카드 이미지·명칭·지역명이 동적으로 표시되고 금액 입력/검증 로직 개선.
  - 지갑 응답 DTO에 regionId/province/city 필드 추가.

- Bug Fixes
  - 결제 비밀번호 불일치 시 하단 토스트 알림 표시, PIN 초기화 후 안전하게 재시도 유도.

- Style
  - 배지 이미지 회색 배경 유틸리티 제거로 시각 표현 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->