### PR TITLE
[Feature/scrum 171] : QA 사항 해결

### DIFF
--- a/src/components/map/KaKaoMapContainer.vue
+++ b/src/components/map/KaKaoMapContainer.vue
@@ -292,7 +292,7 @@ watch(
           emit('current-location')
         }
       "
-      class="absolute bottom-[15rem] right-[1.6rem] z-[200] p-[1.5rem] bg-White-0 rounded-full shadow-lg"
+      class="absolute bottom-[10rem] right-[1.6rem] z-[200] p-[1.5rem] bg-White-0 rounded-full shadow-lg"
       aria-label="현재 위치로 이동"
     >
       <crosshair :size="15" color="#0062ff" />

--- a/src/components/wallet/create/CardBenefitInfo.vue
+++ b/src/components/wallet/create/CardBenefitInfo.vue
@@ -8,7 +8,7 @@ const props = defineProps<{
   /**
    * 최대 충전 가능 금액
    */
-  maxChargeAmount: string
+  maxChargeAmount: number
 }>()
 </script>
 
@@ -21,7 +21,7 @@ const props = defineProps<{
     <!-- 최대 충전 금액 -->
     <div>
       <span class="Body02 text-Gray-5">최대 충전 가능 금액</span>
-      <span class="ms-[0.5rem] Head04 text-Yellow-1">{{ maxChargeAmount }}원</span>
+      <span class="ms-[0.5rem] Head04 text-Yellow-1">{{ maxChargeAmount.toLocaleString() }}원</span>
     </div>
   </div>
 </template>

--- a/src/components/wallet/exchange/ExchageCard.vue
+++ b/src/components/wallet/exchange/ExchageCard.vue
@@ -5,6 +5,7 @@ import { HandCoins } from 'lucide-vue-next'
 import type { BenefitType } from '@/types/local/localTypes'
 import { benefitTypeTextMap } from '@/constants/BenefitMapper'
 import type { WalletResponseDtoType } from '@/types/wallet/WalletResponseDtoType'
+import { isIncentiveWallet } from '@/utils/checkIncentiveType'
 
 // 충전/인센티브 금액 알기위해 날짜 받기
 const currentMonthLabel = format(new Date(), 'M월')
@@ -75,10 +76,7 @@ const selectedCardBenefit = computed(() => {
     <div class="flex flex-col gap-3 mt-[1rem]">
       <div class="flex items-center gap-2">
         <div class="Head04 text-Black-2">{{ props.cardName }}</div>
-        <div
-          v-if="benefitTypeTextMap[benefitType.fromCard] === '인센티브'"
-          class="Body04 text-Gray-5"
-        >
+        <div v-if="isIncentiveWallet(benefitType.fromCard)" class="Body04 text-Gray-5">
           인센티브는 제외하고 환전됩니다
         </div>
       </div>

--- a/src/components/wallet/exchange/ExchageCard.vue
+++ b/src/components/wallet/exchange/ExchageCard.vue
@@ -6,7 +6,7 @@ import type { BenefitType } from '@/types/local/localTypes'
 import { benefitTypeTextMap } from '@/constants/BenefitMapper'
 import type { WalletResponseDtoType } from '@/types/wallet/WalletResponseDtoType'
 import { isIncentiveWallet } from '@/utils/checkIncentiveType'
-import { calculateExchangeRegionToCash } from '@/utils/exchange'
+import { calculateExchangeRegionToRegion } from '@/utils/exchange'
 
 // 충전/인센티브 금액 알기위해 날짜 받기
 const currentMonthLabel = format(new Date(), 'M월')
@@ -55,11 +55,17 @@ const selectedCardBenefit = computed(() => {
 const excludedIncentive = computed(() => {
   if (!props.modelValue || !props.percentage.toCard) return ' - '
 
-  const fromCardPercentage = isIncentiveWallet(props.benefitType.toCard)
-    ? props.percentage.toCard
+  const fromCardPercentage = isIncentiveWallet(props.benefitType.fromCard)
+    ? props.percentage.fromCard
     : 0
 
-  const { finalAmount } = calculateExchangeRegionToCash(fromCardPercentage, props.modelValue)
+  const toCardPercentage = isIncentiveWallet(props.benefitType.toCard) ? props.percentage.toCard : 0
+
+  const { finalAmount } = calculateExchangeRegionToRegion(
+    fromCardPercentage,
+    toCardPercentage,
+    props.modelValue,
+  )
   return finalAmount.toLocaleString()
 })
 </script>

--- a/src/components/wallet/exchange/ExchageCard.vue
+++ b/src/components/wallet/exchange/ExchageCard.vue
@@ -18,7 +18,7 @@ const props = defineProps<{
   modelValue: number | null
   mode?: 'region' | 'cash' // 지역→지역인지, 지역→현금인지 구분
   fromCardName: string
-  benefitType: BenefitType
+  benefitType: { fromCard: BenefitType; toCard: BenefitType }
   toCardList: WalletResponseDtoType[]
 }>()
 
@@ -45,7 +45,7 @@ const handleSelect = () => {
 const selectedCardBenefit = computed(() => {
   const card = props.toCardList.find((c) => c.localCurrencyName === selectedCard.value)
   return card
-    ? `${card.localCurrencyName} 혜택 : ${benefitTypeTextMap[props.benefitType]} ${card.percentage}%`
+    ? `${card.localCurrencyName} 혜택 : ${benefitTypeTextMap[props.benefitType.toCard]} ${card.percentage}%`
     : ''
 })
 </script>
@@ -65,7 +65,9 @@ const selectedCardBenefit = computed(() => {
     <div class="Body03 text-Gray-6">
       {{ currentMonthLabel }} 충전한 금액:
       <span class="Body02 text-Black-2">{{ props.chargedAmount.toLocaleString() }}원</span><br />
-      {{ currentMonthLabel }} 받은 인센티브({{ props.percentage }}%):
+      {{ currentMonthLabel }} 받은 {{ benefitTypeTextMap[benefitType.fromCard] }}({{
+        props.percentage
+      }}%):
       <span class="Body02 text-Black-2">{{ props.incentiveAmount.toLocaleString() }}원</span>
     </div>
 
@@ -73,7 +75,12 @@ const selectedCardBenefit = computed(() => {
     <div class="flex flex-col gap-3 mt-[1rem]">
       <div class="flex items-center gap-2">
         <div class="Head04 text-Black-2">{{ props.cardName }}</div>
-        <div class="Body04 text-Gray-5">인센티브는 제외하고 환전됩니다</div>
+        <div
+          v-if="benefitTypeTextMap[benefitType.fromCard] === '인센티브'"
+          class="Body04 text-Gray-5"
+        >
+          인센티브는 제외하고 환전됩니다
+        </div>
       </div>
 
       <input

--- a/src/components/wallet/exchange/ExchangeCash.vue
+++ b/src/components/wallet/exchange/ExchangeCash.vue
@@ -3,6 +3,8 @@ import { computed } from 'vue'
 import { format } from 'date-fns'
 import { calculateExchangeRegionToCash } from '@/utils/exchange'
 import { HandCoins } from 'lucide-vue-next'
+import { benefitTypeTextMap } from '@/constants/BenefitMapper'
+import type { BenefitType } from '@/types/local/localTypes'
 
 const currentMonthLabel = format(new Date(), 'M월')
 
@@ -13,6 +15,7 @@ const props = defineProps<{
   cardName?: string
   modelValue: number | null
   percentage?: number
+  fromCardBenefit: BenefitType
 }>()
 
 const emit = defineEmits<{
@@ -46,7 +49,9 @@ const excludedIncentive = computed(() => {
     <div class="Body03 text-Gray-6">
       {{ currentMonthLabel }} 충전한 금액:
       <span class="Body02 text-Black-2">{{ props.chargedAmount.toLocaleString() }}원</span><br />
-      {{ currentMonthLabel }} 받은 인센티브({{ props.percentage }}%):
+      {{ currentMonthLabel }} 받은 {{ benefitTypeTextMap[fromCardBenefit] }}({{
+        props.percentage
+      }}%):
       <span class="Body02 text-Black-2">{{ props.incentiveAmount.toLocaleString() }}원</span>
     </div>
 
@@ -54,7 +59,9 @@ const excludedIncentive = computed(() => {
     <div class="flex flex-col gap-3 mt-[1rem]">
       <div class="flex items-center gap-2">
         <div class="Head04 text-Black-2">{{ props.cardName }}</div>
-        <div class="Body04 text-Gray-5">인센티브 비율만큼 차감된 금액으로 환전됩니다</div>
+        <div v-if="benefitTypeTextMap[fromCardBenefit] === '인센티브'" class="Body04 text-Gray-5">
+          인센티브 비율만큼 차감된 금액으로 환전됩니다
+        </div>
       </div>
 
       <input

--- a/src/components/wallet/exchange/ExchangeCash.vue
+++ b/src/components/wallet/exchange/ExchangeCash.vue
@@ -5,6 +5,7 @@ import { calculateExchangeRegionToCash } from '@/utils/exchange'
 import { HandCoins } from 'lucide-vue-next'
 import { benefitTypeTextMap } from '@/constants/BenefitMapper'
 import type { BenefitType } from '@/types/local/localTypes'
+import { isIncentiveWallet } from '@/utils/checkIncentiveType'
 
 const currentMonthLabel = format(new Date(), 'M월')
 
@@ -59,7 +60,7 @@ const excludedIncentive = computed(() => {
     <div class="flex flex-col gap-3 mt-[1rem]">
       <div class="flex items-center gap-2">
         <div class="Head04 text-Black-2">{{ props.cardName }}</div>
-        <div v-if="benefitTypeTextMap[fromCardBenefit] === '인센티브'" class="Body04 text-Gray-5">
+        <div v-if="isIncentiveWallet(fromCardBenefit)" class="Body04 text-Gray-5">
           인센티브 비율만큼 차감된 금액으로 환전됩니다
         </div>
       </div>

--- a/src/components/wallet/exchange/ExchangeCash.vue
+++ b/src/components/wallet/exchange/ExchangeCash.vue
@@ -30,7 +30,10 @@ const handleInput = (e: Event) => {
 // 현금 환전 금액 계산
 const excludedIncentive = computed(() => {
   if (!props.modelValue || !props.percentage) return 0
-  const { finalAmount } = calculateExchangeRegionToCash(props.percentage, props.modelValue)
+
+  const fromCardPercentage = isIncentiveWallet(props.fromCardBenefit) ? props.percentage : 0
+
+  const { finalAmount } = calculateExchangeRegionToCash(fromCardPercentage, props.modelValue)
   return finalAmount
 })
 </script>

--- a/src/components/wallet/modal/ExchangCashConfirmModal.vue
+++ b/src/components/wallet/modal/ExchangCashConfirmModal.vue
@@ -2,11 +2,13 @@
 import { useRouter } from 'vue-router'
 import { ArrowDown } from 'lucide-vue-next'
 import DanjiButton from '@/components/common/button/DanjiButton.vue'
+import type { BenefitType } from '@/types/local/localTypes'
+import { isIncentiveWallet } from '@/utils/checkIncentiveType'
 
 const router = useRouter()
 
 const props = defineProps<{
-  fromCard: { name: string; percentage: number }
+  fromCard: { name: string; percentage: number; benefitType: BenefitType }
   totalAmount: number
   result: { finalAmount: number; excludedIncentive: number }
 }>()
@@ -15,6 +17,14 @@ const emit = defineEmits<{
   (e: 'close'): void
   (e: 'confirm'): void
 }>()
+
+const calculateFinalAmount = () => {
+  if (isIncentiveWallet(props.fromCard.benefitType)) {
+    return props.result.finalAmount.toLocaleString()
+  } else {
+    return props.totalAmount.toLocaleString()
+  }
+}
 </script>
 
 <template>
@@ -32,7 +42,7 @@ const emit = defineEmits<{
             환전 예정 금액:
             <span class="text-Black-1">{{ props.totalAmount.toLocaleString() }}원</span>
           </p>
-          <p class="Body03 text-Gray-6">
+          <p v-if="isIncentiveWallet(fromCard.benefitType)" class="Body03 text-Gray-6">
             제외된 인센티브:
             <span class="text-Red-1">{{ props.result.excludedIncentive.toLocaleString() }}원</span>
           </p>
@@ -47,14 +57,14 @@ const emit = defineEmits<{
           <p class="pb-[0.6rem] Body02">통합지갑</p>
           <p class="mt-[0.8rem] Body03 text-Gray-6">
             최종 충전 금액:
-            <span class="text-Black-1">{{ props.result.finalAmount.toLocaleString() }}원</span>
+            <span class="text-Black-1">{{ calculateFinalAmount() }}원</span>
           </p>
         </div>
       </div>
 
       <div class="mb-[2rem] text-center Head02">
         최종 환전 금액:
-        <span class="text-Red-1">{{ props.result.finalAmount.toLocaleString() }}원</span>
+        <span class="text-Red-1">{{ calculateFinalAmount() }}원</span>
       </div>
 
       <div class="w-full max-w-[34.3rem] flex gap-3">

--- a/src/components/wallet/modal/ExchangeCardConfirmModal.vue
+++ b/src/components/wallet/modal/ExchangeCardConfirmModal.vue
@@ -2,12 +2,14 @@
 import { computed } from 'vue'
 import DanjiButton from '@/components/common/button/DanjiButton.vue'
 import { calculateExchangeRegionToRegion } from '@/utils/exchange'
+import { isIncentiveWallet } from '@/utils/checkIncentiveType'
 
 import { ArrowDown } from 'lucide-vue-next'
+import type { BenefitType } from '@/types/local/localTypes'
 
 const props = defineProps<{
-  fromCard: { name: string; percentage: number }
-  toCard: { name: string; percentage: number }
+  fromCard: { name: string; percentage: number; benefitType: BenefitType }
+  toCard: { name: string; percentage: number; benefitType: BenefitType }
   totalAmount: number
 }>()
 
@@ -16,14 +18,32 @@ const emit = defineEmits<{
   (e: 'confirm'): void
 }>()
 
+const fromCardPercentage = isIncentiveWallet(props.fromCard.benefitType)
+  ? props.fromCard.percentage
+  : 0
+
+const toCardPercentage = isIncentiveWallet(props.toCard.benefitType) ? props.fromCard.percentage : 0
+
 // 계산 결과 가져오기
 const exchangeResult = computed(() =>
-  calculateExchangeRegionToRegion(
-    props.fromCard.percentage,
-    props.toCard.percentage,
-    props.totalAmount,
-  ),
+  calculateExchangeRegionToRegion(fromCardPercentage, toCardPercentage, props.totalAmount),
 )
+
+const exchangeCalculationDescription = computed(() => {
+  const fromIsIncentive = isIncentiveWallet(props.fromCard.benefitType)
+  const toIsIncentive = isIncentiveWallet(props.toCard.benefitType)
+
+  if (fromIsIncentive && toIsIncentive) {
+    return `환전 시 기존 카드 인센티브(${props.fromCard.percentage}%)는 제외되며, \n환전할 카드 인센티브(${props.toCard.percentage}%)가 새로 적용됩니다.`
+  }
+  if (fromIsIncentive && !toIsIncentive) {
+    return `환전 시 기존 카드 인센티브(${props.fromCard.percentage}%)는 제외되며, \n환전할 카드의 혜택은 추후 결제 시 적용됩니다.`
+  }
+  if (!fromIsIncentive && toIsIncentive) {
+    return `환전할 카드 인센티브(${props.toCard.percentage}%)가 새로 적용됩니다.`
+  }
+  return `환전할 카드의 혜택은 추후 결제 시 적용됩니다.`
+})
 </script>
 
 <template>
@@ -52,7 +72,7 @@ const exchangeResult = computed(() =>
             충전 금액:
             <span class="text-Yellow-1">{{ exchangeResult.baseAmount.toLocaleString() }}원</span>
           </p>
-          <p class="Body03 text-Gray-6 mb-[0.2rem]">
+          <p v-if="isIncentiveWallet(toCard.benefitType)" class="Body03 text-Gray-6 mb-[0.2rem]">
             인센티브:
             <span class="text-Yellow-1">{{ exchangeResult.incentive.toLocaleString() }}원</span>
           </p>
@@ -63,9 +83,8 @@ const exchangeResult = computed(() =>
         최종 환전 금액:
         <span class="text-Black-2">{{ exchangeResult.finalAmount.toLocaleString() }}원</span>
       </div>
-      <div class="mb-[1rem] text-center text-Gray-5 Body03">
-        ※ 환전 시 전 카드의 인센티브( {{ props.fromCard.percentage }}% )는 제외되고, <br />
-        환전할 카드의 인센티브( {{ props.toCard.percentage }}% )만 새로 적용됩니다.
+      <div class="mb-[1rem] text-center text-Gray-5 Body03 whitespace-pre-line">
+        ※ {{ exchangeCalculationDescription }}
       </div>
 
       <div class="w-full max-w-[34.3rem] flex gap-3">

--- a/src/components/wallet/modal/ExchangeCardConfirmModal.vue
+++ b/src/components/wallet/modal/ExchangeCardConfirmModal.vue
@@ -18,16 +18,15 @@ const emit = defineEmits<{
   (e: 'confirm'): void
 }>()
 
-const fromCardPercentage = isIncentiveWallet(props.fromCard.benefitType)
-  ? props.fromCard.percentage
-  : 0
-
-const toCardPercentage = isIncentiveWallet(props.toCard.benefitType) ? props.fromCard.percentage : 0
-
 // 계산 결과 가져오기
-const exchangeResult = computed(() =>
-  calculateExchangeRegionToRegion(fromCardPercentage, toCardPercentage, props.totalAmount),
-)
+const exchangeResult = computed(() => {
+  const fromCardPercentage = isIncentiveWallet(props.fromCard.benefitType)
+    ? props.fromCard.percentage
+    : 0
+  const toCardPercentage = isIncentiveWallet(props.toCard.benefitType) ? props.toCard.percentage : 0
+
+  return calculateExchangeRegionToRegion(fromCardPercentage, toCardPercentage, props.totalAmount)
+})
 
 const exchangeCalculationDescription = computed(() => {
   const fromIsIncentive = isIncentiveWallet(props.fromCard.benefitType)

--- a/src/components/wallet/modal/ExchangeCardConfirmModal.vue
+++ b/src/components/wallet/modal/ExchangeCardConfirmModal.vue
@@ -56,7 +56,7 @@ const exchangeCalculationDescription = computed(() => {
           <p class="pb-[0.6rem] Body02">{{ props.fromCard.name }}</p>
           <p class="Body03 text-Gray-6 mt-[1rem]">
             환전 예정 금액:
-            <span class="text-Yellow-1">{{ props.totalAmount.toLocaleString() }}원</span>
+            <span class="Body02 text-Black-1">{{ props.totalAmount.toLocaleString() }}원</span>
           </p>
         </div>
 
@@ -69,18 +69,23 @@ const exchangeCalculationDescription = computed(() => {
           <p class="pb-[0.6rem] Body02">{{ props.toCard.name }}</p>
           <p class="Body03 text-Gray-6 mb-[0.2rem]">
             충전 금액:
-            <span class="text-Yellow-1">{{ exchangeResult.baseAmount.toLocaleString() }}원</span>
+            <span class="Body02 text-Black-1"
+              >{{ exchangeResult.baseAmount.toLocaleString() }}원</span
+            >
           </p>
           <p v-if="isIncentiveWallet(toCard.benefitType)" class="Body03 text-Gray-6 mb-[0.2rem]">
             인센티브:
-            <span class="text-Yellow-1">{{ exchangeResult.incentive.toLocaleString() }}원</span>
+            <span class="Body02 text-Black-1"
+              >{{ exchangeResult.incentive.toLocaleString() }}원</span
+            >
           </p>
         </div>
       </div>
 
       <div class="mb-[2rem] text-center Head02">
         최종 환전 금액:
-        <span class="text-Black-2">{{ exchangeResult.finalAmount.toLocaleString() }}원</span>
+        <span class="text-Blue-0"> {{ exchangeResult.finalAmount.toLocaleString() }}</span>
+        <span class="ms-[0.2rem]">원</span>
       </div>
       <div class="mb-[1rem] text-center text-Gray-5 Body03 whitespace-pre-line">
         ※ {{ exchangeCalculationDescription }}

--- a/src/composables/local/useLocalSelector.ts
+++ b/src/composables/local/useLocalSelector.ts
@@ -87,13 +87,7 @@ export default function useLocalSelector() {
   // 특정 지역 설정 (외부에서 초기값 설정 시 사용)
   const setLocal = (region?: string, city?: string) => {
     selectedRegion.value = region ?? ''
-
-    // city selector가 보여지는 경우에만 city 설정
-    if (city && shouldShowCitySelector.value) {
-      selectedCity.value = city
-    } else {
-      selectedCity.value = ''
-    }
+    selectedCity.value = city ?? ''
   }
 
   const getLocalInfoById = (cityId: number) => {

--- a/src/utils/checkIncentiveType.ts
+++ b/src/utils/checkIncentiveType.ts
@@ -1,0 +1,6 @@
+import { benefitTypeTextMap } from '@/constants/BenefitMapper'
+import type { BenefitType } from '@/types/local/localTypes'
+
+export const isIncentiveWallet = (benefitType: BenefitType) => {
+  return benefitTypeTextMap[benefitType] === '인센티브'
+}

--- a/src/views/wallet/charge/CardChargePage.vue
+++ b/src/views/wallet/charge/CardChargePage.vue
@@ -62,14 +62,22 @@ const incentive = computed(() =>
 // 실제 결제 금액(통합지갑에서 빠질 금액) — 수수료 면제 시 수수료 없음
 const actualCharge = computed(() => (EVENT_FEE_FREE ? amount.value : amount.value + fee.value))
 
-// 최종 충전 금액 (충전 금액 + 인센티브)
+// 최종 충전 금액 (인센 : 충전 금액 + 인센티브, 그 외 : 충전 금액만)
 const finalChargeAmount = computed(() => {
-  return amount.value + incentive.value
+  if (isIncentive()) {
+    return amount.value + incentive.value
+  } else {
+    return amount.value
+  }
 })
 
-// 충전 후 지역화폐 잔액
+// 충전 후 지역화폐 잔액 (인센 : 인센 포함 더한 금액, 그 외 : 충전 금액만 더함)
 const localCurrencyAfterCharge = computed(() => {
-  return localBalance.value + amount.value + incentive.value
+  if (isIncentive()) {
+    return localBalance.value + amount.value + incentive.value
+  } else {
+    return localBalance.value + amount.value
+  }
 })
 
 // 충전 후 통합지갑 잔액 — 이벤트 중 수수료 미반영
@@ -118,6 +126,8 @@ const handleCharge = async () => {
     query: { success: result.success ? 'true' : 'false' },
   })
 }
+
+const isIncentive = () => benefitTypeTextMap[localWalletInfo.value.benefitType] === '인센티브'
 </script>
 
 <template>
@@ -183,7 +193,7 @@ const handleCharge = async () => {
                 </span>
                 <span v-if="amount" class="text-Red-0">수수료 면제 대상입니다!</span>
               </p>
-              <p v-if="benefitTypeTextMap[localWalletInfo.benefitType] === '인센티브'">
+              <p v-if="isIncentive()">
                 {{ localWalletInfo.localCurrencyName }}
                 인센티브({{ localWalletInfo.percentage }}%):
                 <span class="text-Yellow-0">{{ incentive.toLocaleString() }}원</span>
@@ -220,11 +230,9 @@ const handleCharge = async () => {
                 통합지갑 잔액이 부족하여 충전할 수 없습니다.
               </p>
               <!-- 캐쉬백 안내 -->
-              <p
-                v-if="benefitTypeTextMap[localWalletInfo.benefitType] === '캐시백'"
-                class="text-Red-0 Body04"
-              >
-                캐시백 {{ incentive.toLocaleString() }}원은 다음 달에 지급됩니다.
+              <p v-if="!isIncentive()" class="text-Red-0 Body04">
+                {{ benefitTypeTextMap[localWalletInfo.benefitType] }}
+                {{ incentive.toLocaleString() }}원은 다음 달에 지급됩니다.
               </p>
             </div>
           </section>

--- a/src/views/wallet/charge/CardChargePage.vue
+++ b/src/views/wallet/charge/CardChargePage.vue
@@ -9,6 +9,7 @@ import { TRANSACTION_TYPE } from '@/constants/Transaction'
 import useGetWallet from '@/composables/queries/wallet/useGetWallet'
 import { benefitTypeTextMap } from '@/constants/BenefitMapper'
 import useGetWalletList from '@/composables/queries/wallet/useGetWalletList'
+import { isIncentiveWallet } from '@/utils/checkIncentiveType'
 
 const router = useRouter()
 const route = useRoute()
@@ -64,7 +65,7 @@ const actualCharge = computed(() => (EVENT_FEE_FREE ? amount.value : amount.valu
 
 // 최종 충전 금액 (인센 : 충전 금액 + 인센티브, 그 외 : 충전 금액만)
 const finalChargeAmount = computed(() => {
-  if (isIncentive()) {
+  if (isIncentiveWallet(localWalletInfo.value.benefitType)) {
     return amount.value + incentive.value
   } else {
     return amount.value
@@ -73,7 +74,7 @@ const finalChargeAmount = computed(() => {
 
 // 충전 후 지역화폐 잔액 (인센 : 인센 포함 더한 금액, 그 외 : 충전 금액만 더함)
 const localCurrencyAfterCharge = computed(() => {
-  if (isIncentive()) {
+  if (isIncentiveWallet(localWalletInfo.value.benefitType)) {
     return localBalance.value + amount.value + incentive.value
   } else {
     return localBalance.value + amount.value
@@ -126,8 +127,6 @@ const handleCharge = async () => {
     query: { success: result.success ? 'true' : 'false' },
   })
 }
-
-const isIncentive = () => benefitTypeTextMap[localWalletInfo.value.benefitType] === '인센티브'
 </script>
 
 <template>
@@ -193,7 +192,7 @@ const isIncentive = () => benefitTypeTextMap[localWalletInfo.value.benefitType] 
                 </span>
                 <span v-if="amount" class="text-Red-0">수수료 면제 대상입니다!</span>
               </p>
-              <p v-if="isIncentive()">
+              <p v-if="isIncentiveWallet(localWalletInfo.benefitType)">
                 {{ localWalletInfo.localCurrencyName }}
                 인센티브({{ localWalletInfo.percentage }}%):
                 <span class="text-Yellow-0">{{ incentive.toLocaleString() }}원</span>
@@ -230,7 +229,7 @@ const isIncentive = () => benefitTypeTextMap[localWalletInfo.value.benefitType] 
                 통합지갑 잔액이 부족하여 충전할 수 없습니다.
               </p>
               <!-- 캐쉬백 안내 -->
-              <p v-if="!isIncentive()" class="text-Red-0 Body04">
+              <p v-if="!isIncentiveWallet(localWalletInfo.benefitType)" class="text-Red-0 Body04">
                 {{ benefitTypeTextMap[localWalletInfo.benefitType] }}
                 {{ incentive.toLocaleString() }}원은 다음 달에 지급됩니다.
               </p>

--- a/src/views/wallet/create/LocalCardCreateDetailPage.vue
+++ b/src/views/wallet/create/LocalCardCreateDetailPage.vue
@@ -18,7 +18,8 @@ const routeCityId = computed(() => Number(route.params.id))
 
 const isModalVisible = ref<boolean>(false)
 
-const { selectedRegion, selectedCity, selectedCityId, getLocalInfoById } = useLocalSelector()
+const { selectedRegion, selectedCity, selectedCityId, getLocalInfoById, setLocal } =
+  useLocalSelector()
 const { localCurrencyName, benefitInfo, benefitDescription, localCurrencyId } =
   useLocalCurrencyInfo(
     computed(() => ({
@@ -37,8 +38,7 @@ const handleClickModal = (): void => {
 }
 
 const handleModalConfirm = async (region: string, city: string): Promise<void> => {
-  selectedRegion.value = region
-  selectedCity.value = city
+  setLocal(region, city)
   isModalVisible.value = false
 
   await nextTick()

--- a/src/views/wallet/create/LocalCardCreateDetailPage.vue
+++ b/src/views/wallet/create/LocalCardCreateDetailPage.vue
@@ -99,7 +99,7 @@ const handleCompeleteClick = () => {
         <!-- 카드 이미지 & 이름 컴포넌트 -->
         <card-info
           :card-name="localCurrencyName"
-          :card-image="`http://danji.cloud${benefitInfo?.img}`"
+          :card-image="benefitInfo?.img ? `http://danji.cloud${benefitInfo.img}` : undefined"
         />
 
         <!-- 카드 혜택 정보 컴포넌트 -->

--- a/src/views/wallet/create/LocalCardCreateDetailPage.vue
+++ b/src/views/wallet/create/LocalCardCreateDetailPage.vue
@@ -105,7 +105,7 @@ const handleCompeleteClick = () => {
         <!-- 카드 혜택 정보 컴포넌트 -->
         <card-benefit-info
           :incentive-text="benefitDescription"
-          :max-charge-amount="String(benefitInfo?.maximum ?? 0)"
+          :max-charge-amount="benefitInfo?.maximum ?? 0"
         />
 
         <!-- 하단 버튼 -->

--- a/src/views/wallet/create/LocalCardCreateDetailPage.vue
+++ b/src/views/wallet/create/LocalCardCreateDetailPage.vue
@@ -110,8 +110,8 @@ const handleCompeleteClick = () => {
 
         <!-- 하단 버튼 -->
         <div class="flex justify-center mt-[3.4rem] mb-[4rem]">
-          <danji-button variant="large" @click="handleCompeleteClick" :disabled="isPending"
-            >발급하기</danji-button
+          <danji-button variant="large" @click="handleCompeleteClick" :disabled="isPending">
+            {{ isPending ? '발급하는 중…' : '발급하기' }}</danji-button
           >
         </div>
       </div>

--- a/src/views/wallet/exchange/ExchangePage.vue
+++ b/src/views/wallet/exchange/ExchangePage.vue
@@ -223,6 +223,7 @@ const confirmExchange = (isConvert: boolean) => {
             :from-card="{
               name: selectedCard.localCurrencyName,
               percentage: selectedCard.percentage,
+              benefitType: selectedCard.benefitType,
             }"
             :total-amount="exchangeInput || 0"
             :result="exchangeResult"

--- a/src/views/wallet/exchange/ExchangePage.vue
+++ b/src/views/wallet/exchange/ExchangePage.vue
@@ -165,7 +165,10 @@ const confirmExchange = (isConvert: boolean) => {
               :incentiveAmount="incentiveAmount"
               :cardName="selectedCard.localCurrencyName"
               :fromCardName="selectedCard.localCurrencyName"
-              :benefit-type="selectedToCardData.benefitType"
+              :benefit-type="{
+                fromCard: selectedCard.benefitType,
+                toCard: selectedToCardData.benefitType,
+              }"
               :to-card-list="cardList.filter((item) => item.walletId !== cardId)"
             />
 
@@ -179,6 +182,7 @@ const confirmExchange = (isConvert: boolean) => {
               :incentiveAmount="incentiveAmount"
               :cardName="selectedCard.localCurrencyName"
               :percentage="selectedCard.percentage"
+              :from-card-benefit="selectedCard.benefitType"
             />
           </div>
 

--- a/src/views/wallet/exchange/ExchangePage.vue
+++ b/src/views/wallet/exchange/ExchangePage.vue
@@ -160,7 +160,10 @@ const confirmExchange = (isConvert: boolean) => {
               mode="region"
               @select-card="(value) => (selectedToCard = value)"
               :balance="selectedCard.balance"
-              :percentage="selectedCard.percentage"
+              :percentage="{
+                fromCard: selectedCard.percentage,
+                toCard: selectedToCardData.percentage,
+              }"
               :chargedAmount="chargedAmountThisMonth"
               :incentiveAmount="incentiveAmount"
               :cardName="selectedCard.localCurrencyName"

--- a/src/views/wallet/exchange/ExchangePage.vue
+++ b/src/views/wallet/exchange/ExchangePage.vue
@@ -204,10 +204,12 @@ const confirmExchange = (isConvert: boolean) => {
             :from-card="{
               name: selectedCard.localCurrencyName,
               percentage: selectedCard.percentage,
+              benefitType: selectedCard.benefitType,
             }"
             :to-card="{
               name: selectedToCardData.localCurrencyName,
               percentage: selectedToCardData.percentage,
+              benefitType: selectedToCardData.benefitType,
             }"
             :total-amount="exchangeInput || 0"
             :result="exchangeResult"


### PR DESCRIPTION
## 📌 Issues
- closed #111 

## 🏁 Work Description
- 환전하기 모달 수정(텍스트 색상, 혜택 타입 매핑)
- 카드 발급 금액에 , 붙이도록 설정
- 카드 발급 쪽에 지역 선택 시 행정 구역 선택 안되는 오류 수정

## 정책 정리
**[지역 카드 종류]**
```javascript
광주(광주상생카드) : 할인 충전 10%
대구(대구로페이) : 할인 충전 10%
부산(동백전) : 캐시백 5%
울산(울산페이) : 인센티브 7%
군산(군산사랑상품권) : 할인 충전 10%
익산(익산다이로움) : 인센티브 5%
제주(탐나는전) : 인센티브 10%
```

**[충전하기 정책]**
```javascript
인센티브 카드들은 원금 + 인센티브를 충전한다.
인센티브를 제외한 캐시백, 할인 충전 카드들은 원금을 충전한다.
```

**[환전하기 정책]**
```javascript
인센티브를 제외한 캐시백, 할인 충전 카드들은 원금을 환전한다.
1. 인센티브 -> 인센티브 (기존 인센 제외, 새로운 인센 추가)
2. 인센티브 -> 캐시백 (기존 인센 제외, 추가 x)
3. 인센티브 -> 할인충전 (기존 인센 제외, 추가 x)
4. 캐시백 -> 인센티브 (제외x, 새로운 인센 추가)
5. 캐시백 -> 캐시백 (제외 x, 추가 x)
6. 캐시백 -> 할인충전 (제외 x, 추가 x)
7. 할인충전 -> 인센티브 (제외 x, 새로운 인센 추가)
8. 할인충전 -> 캐시백 (제외 x, 추가 x)
9. 할인충전 -> 할인충전 (제외 x, 추가 x)
```

**[환불하기 정책]**
```javascript
인센티브 카드들은 원금 - 인센티브를 환불한다.
인센티브를 제외한 캐시백, 할인 충전 카드들은 원금을 환불한다.
``` 

## 💬 PR Points
- 캐시백, 할인 충전 타입을 분기처리하면서 보여지는 정보가 조금씩 바뀌었습니다. 스크린샷 확인 부탁드려요!!
- 환전하기 모달 텍스트 색상을 일단 파란색으로 처리하긴 했는데, 나중에 보고 이상하면 수정하면 될 듯합니다~!
- 충전/환전/환불 관련 로직 이상한 부분 있으면 알려주세요~~

## 📷 Screenshot
### 환전하기
| 인센티브 -> 인센티브 | 인센티브 -> 인센티브 (모달) | 인센티브 -> 캐시백/할인충전 | 인센티브 -> 캐시백/할인충전(모달) |
|--------|--------|--------|--------|
| <img width="750" height="1334" alt="localhost_5173_home(iPhone SE)" src="https://github.com/user-attachments/assets/c56f740c-a860-4040-bd2c-8167b7e76f8c" /> | <img width="750" height="1334" alt="localhost_5173_home(iPhone SE) (1)" src="https://github.com/user-attachments/assets/da0da562-1653-4854-8c35-e99e61e4ebc0" /> | <img width="750" height="1334" alt="localhost_5173_home(iPhone SE) (2)" src="https://github.com/user-attachments/assets/e3913377-4cbc-4a6d-acaa-dbd7cc1a5f3d" /> | <img width="750" height="1334" alt="localhost_5173_home(iPhone SE) (3)" src="https://github.com/user-attachments/assets/eb6e041c-6040-47e4-b861-c396683beb9f" /> |

| 캐시백/할인충전 -> 인센티브 | 캐시백/할인충전 -> 인센티브(모달) | 캐시백/할인충전 -> 캐시백/할인충전 | 캐시백/할인충전 -> 캐시백/할인충전(모달) |
|--------|--------|--------|--------|
| <img width="750" height="1334" alt="localhost_5173_home(iPhone SE) (4)" src="https://github.com/user-attachments/assets/001ff1dd-d60d-49d7-81fa-a61975546b88" /> | <img width="750" height="1334" alt="localhost_5173_home(iPhone SE) (5)" src="https://github.com/user-attachments/assets/0e20f2fe-1bfc-4edd-ba93-f131360f193b" /> | <img width="750" height="1334" alt="localhost_5173_home(iPhone SE) (6)" src="https://github.com/user-attachments/assets/fb01b34d-0e32-4368-822d-bfe4cd4897fd" /> | <img width="750" height="1334" alt="localhost_5173_home(iPhone SE) (7)" src="https://github.com/user-attachments/assets/b848dd4e-70b5-41b5-9a94-61b0f9a005c0" /> | 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 카드별 혜택을 인식해 교환/환전 시 인센티브 제외 금액을 자동 계산하고, 확인 모달에 상황별 계산 결과와 설명을 동적으로 표시합니다.
  - 교환·환전 흐름 전반에 카드별 혜택 정보가 반영됩니다.
- Style
  - 금액을 로컬 형식으로 표시하도록 개선하고 일부 금액/안내 색상 및 레이아웃을 조정했습니다.
  - “받은 인센티브” 라벨이 혜택 유형에 맞게 동적으로 표시됩니다.
  - 카드 발급 버튼이 진행 상태에 따라 “발급하는 중…”으로 변경됩니다.
- Bug Fixes
  - 지역/도시 선택 처리 일관성을 개선했습니다.
- UI
  - 지도에서 현재 위치 버튼의 세로 위치를 아래쪽으로 조정해 시각적 배치를 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->